### PR TITLE
[20250827] 키오스크 실행 세션 부분 MapperTest 중

### DIFF
--- a/DB 정리.txt
+++ b/DB 정리.txt
@@ -49,31 +49,28 @@ create table point_request (
     FOREIGN KEY (member_id) REFERENCES member(member_id) ON DELETE RESTRICT
 );
 
--- Kiosk (키오스크) 테이블
+-- 키오스크 장치 정보(kiosk)
 CREATE TABLE IF NOT EXISTS kiosk (
-  kiosk_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-  name VARCHAR(100)  NOT NULL, -- 표기명
-  location VARCHAR(255)  NOT NULL, -- 설치 장소
-  lat DECIMAL(10,7) NULL,
-  lng DECIMAL(10,7) NULL,
+  kiosk_id BIGINT AUTO_INCREMENT PRIMARY KEY, -- 장치 PK
+  name VARCHAR(100)  NOT NULL, -- 표시명
+  location VARCHAR(255)  NOT NULL, -- 설치 매장/주소
+  lat DECIMAL(10,7) NULL, -- 위도
+  lng DECIMAL(10,7) NULL, -- 경도
   status ENUM('ONLINE','OFFLINE','MAINT') NOT NULL DEFAULT 'OFFLINE',
   sw_version VARCHAR(50)   NULL,
-  last_seen_at DATETIME NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, -- 생성 시각
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, -- 마지막 수정 시각
+  is_deleted TINYINT(1) NOT NULL DEFAULT 0 -- 소프트 삭제 (0=정상, 1=삭제)
 );
 
-
--- Kiosk Heartbeat (헬스로그) 테이블
-CREATE TABLE IF NOT EXISTS kiosk_heartbeat (
-  heartbeat_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-  kiosk_id BIGINT NOT NULL,
-  camera_ok TINYINT(1) NOT NULL DEFAULT 1,  -- 1=정상, 0=이상
-  is_online TINYINT(1) NOT NULL DEFAULT 1, -- 1=온라인, 0=오프라인
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  CONSTRAINT fk_hb_kiosk
-    FOREIGN KEY (kiosk_id) REFERENCES kiosk(kiosk_id)
-    ON DELETE CASCADE
+-- 키오스크 가동 이력(kiosk_run)
+CREATE TABLE IF NOT EXISTS kiosk_run (
+  run_id BIGINT AUTO_INCREMENT PRIMARY KEY, -- 세션 PK
+  kiosk_id BIGINT NOT NULL, -- FK
+  member_id BIGINT NULL, -- FK
+  status ENUM('RUNNING','COMPLETED','CANCELLED') NOT NULL DEFAULT 'RUNNING',
+  started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ended_at  DATETIME NULL,
+  FOREIGN KEY (kiosk_id) REFERENCES kiosk(kiosk_id),
+  FOREIGN KEY (member_id) REFERENCES member(member_id)
 );
-
--- 장치별 최근 순 조회 인덱스
-CREATE INDEX idx_hb_kiosk_created ON kiosk_heartbeat(kiosk_id, created_at);

--- a/backend/petcoin/src/main/java/com/petcoin/domain/KioskRunVO.java
+++ b/backend/petcoin/src/main/java/com/petcoin/domain/KioskRunVO.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
  * @since   : 250826
  * @history
  *     - 250826 | yukyeong | VO 최초 생성
+ *     - 250827 | yukyeong | startedAt, endedAt 필드명 수정
  */
 
 @Getter @Setter
@@ -29,11 +30,12 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 public class KioskRunVO {
+
     private Long runId;
     private Long kioskId;
     private Long memberId;
     private RunStatus status;
-    private LocalDateTime startAt;
-    private LocalDateTime endAt;
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
 
 }

--- a/backend/petcoin/src/main/java/com/petcoin/domain/KioskVO.java
+++ b/backend/petcoin/src/main/java/com/petcoin/domain/KioskVO.java
@@ -17,12 +17,15 @@ import java.time.LocalDateTime;
  * - status : 장치 상태(ONLINE/OFFLINE/MAINT) - Enum 매핑
  * - swVersion : 소프트웨어 버전
  * - createdAt : 등록일시
+ * - updatedAt : 수정일시
+ * - isDeleted : 소프트 삭제 여부 (0=정상, 1=삭제)
  *
  * @author  : yukyeong
  * @fileName: KioskVO
  * @since   : 250826
  * @history
  *     - 250826 | yukyeong | VO 최초 생성
+ *     - 250826 | yukyeong | updatedAt, isDeleted 필드 추가
  */
 
 @Getter @Setter
@@ -39,4 +42,6 @@ public class KioskVO {
     private KioskStatus status;
     private String swVersion;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Boolean isDeleted;
 }

--- a/backend/petcoin/src/main/java/com/petcoin/dto/KioskResponse.java
+++ b/backend/petcoin/src/main/java/com/petcoin/dto/KioskResponse.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
  * @since   : 250826
  * @history
  *   - 250826 | yukyeong | DTO 최초 생성
+ *   - 250827 | yukyeong | updatedAt 필드 추가
  */
 
 @Getter @Setter
@@ -39,4 +40,5 @@ public class KioskResponse {
     private KioskStatus status;
     private String swVersion;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/backend/petcoin/src/main/java/com/petcoin/dto/KioskRunCriteria.java
+++ b/backend/petcoin/src/main/java/com/petcoin/dto/KioskRunCriteria.java
@@ -1,0 +1,56 @@
+package com.petcoin.dto;
+
+import com.petcoin.constant.RunStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/*
+ * 키오스크 실행 이력 조회 Criteria
+ * 실행 로그를 페이징/검색 조건으로 조회하기 위한 DTO
+ *
+ * 주요 기능:
+ * - 특정 키오스크별 실행 이력 조회
+ * - 실행 상태(RUNNING/COMPLETED/CANCELLED)별 필터링
+ * - 회원 ID 기반 실행 이력 조회
+ * - 시작 시각 기간 조건 (startedFrom ~ startedTo)
+ * - 페이징(pageNum, amount, offset) 지원
+ *
+ * @author  : yukyeong
+ * @fileName: KioskRunCriteria
+ * @since   : 250827
+ * @history
+ *   - 250827 | yukyeong | 최초 생성 (필터 조건 및 페이징 처리 필드 정의, getOffset() 추가)
+ */
+
+@Getter @Setter
+@ToString
+public class KioskRunCriteria {
+
+    // 필드
+    private Long kioskId; // 특정 키오스크 조회
+    private RunStatus status; // 세션 상태 필터
+    private Long memberId; // 특정 사용자 세션 필터
+    private LocalDateTime startedFrom; // started_at >= from
+    private LocalDateTime startedTo; // started_at <= to
+
+    // 페이징
+    private int pageNum; // 페이지 번호
+    private int amount; // 한 페이지에 보여줄 개수
+
+    public KioskRunCriteria(){
+        this(1,10);
+    }
+
+    // 원하는 페이지, 게시글 수 직접 설정
+    public KioskRunCriteria(int pageNum, int amount){
+        this.pageNum = pageNum;
+        this.amount = amount;
+    }
+
+    // MySQL용 offset
+    public int getOffset() {
+        return (pageNum - 1) * amount;
+    }
+
+}

--- a/backend/petcoin/src/main/java/com/petcoin/dto/KioskRunResponse.java
+++ b/backend/petcoin/src/main/java/com/petcoin/dto/KioskRunResponse.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
  * - runId : 실행 세션 PK
  * - kioskId : 키오스크 FK
  * - memberId : 사용자 FK(null 가능)
+ * - phone : 회원 연락처 (비회원일 경우 null)
  * - status : RUNNING / COMPLETED / CANCELLED
  * - startedAt : 시작 시각
  * - endedAt : 종료 시각(null 가능)
@@ -23,6 +24,7 @@ import java.time.LocalDateTime;
  * @since   : 250826
  * @history
  *   - 250826 | yukyeong | DTO 최초 생성
+ *   - 250827 | yukyeong | 단건조회에서 핸드폰번호 조회를 위해 phone 추가
  */
 
 @Getter @Setter
@@ -34,6 +36,7 @@ public class KioskRunResponse {
     private Long runId;
     private Long kioskId;
     private Long memberId;
+    private String phone;
     private RunStatus status;
     private LocalDateTime startedAt;
     private LocalDateTime endedAt;

--- a/backend/petcoin/src/main/java/com/petcoin/mapper/KioskRunMapper.java
+++ b/backend/petcoin/src/main/java/com/petcoin/mapper/KioskRunMapper.java
@@ -1,0 +1,57 @@
+package com.petcoin.mapper;
+
+import com.petcoin.domain.KioskRunVO;
+import com.petcoin.dto.KioskRunCriteria;
+import com.petcoin.dto.KioskRunResponse;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/*
+ * 키오스크 실행 세션 Mapper 인터페이스
+ * DB 연동을 통해 실행 세션 생성, 상태 변경(완료/취소), 단건 조회, 목록 조회, 중복 실행 체크 등을 수행
+ *
+ * 주요 기능:
+ * - 실행 세션 생성 (insertRun)
+ * - 실행 세션 단건 조회 (readRun)
+ * - 실행 세션 목록 조회 (getRunListWithPaging)
+ * - 실행 세션 총 개수 조회 (getTotalRunCount)
+ * - 실행 완료 처리 (completeRun)
+ * - 실행 취소 처리 (cancelRun)
+ * - 특정 키오스크 RUNNING 세션 존재 여부 확인 (getRunningCountByKioskId)
+ *
+ * @author  : yukyeong
+ * @fileName: KioskRunMapper
+ * @since   : 250827
+ * @history
+ *   - 250827 | yukyeong | Mapper 최초 생성 (insertRun, completeRun, cancelRun, readRun, getRunListWithPaging, getTotalRunCount, getRunningCountByKioskId 메서드 정의)
+ */
+
+@Mapper
+public interface KioskRunMapper {
+
+    // 1) 실행 세션 생성 (RUNNING 상태로 시작)
+    public int insertRun(KioskRunVO vo); // useGeneratedKeys로 runId 채움
+
+    // 2) 실행 완료 처리 (RUNNING -> COMPLETED)
+    public int completeRun(@Param("runId") Long runId,
+                           @Param("endedAt")LocalDateTime endedAt);
+
+    // 3) 실행 취소 처리 (RUNNING -> CANCELLED)
+    public int cancelRun(@Param("runId") Long runId,
+                  @Param("endedAt") LocalDateTime endedAt);
+
+    // 4) 실행 세션 단건 조회 (단건 조회는 phone 포함 DTO로 반환)
+    public KioskRunResponse readRun(Long runId);
+
+    // 5) 실행 세션 목록 조회 (페이징 + 조건)
+    public List<KioskRunVO> getRunListWithPaging(KioskRunCriteria cri);
+
+    // 6) 실행 세션 총 개수 조회 (페이징 + 조건)
+    public int getTotalRunCount(KioskRunCriteria cri);
+
+    // 7) 특정 키오스크 RUNNING 세션 중복 실행 여부 확인
+    public int getRunningCountByKioskId(Long kioskId);
+}

--- a/backend/petcoin/src/main/resources/mapper/KioskRunMapper.xml
+++ b/backend/petcoin/src/main/resources/mapper/KioskRunMapper.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+ * 키오스크 실행 세션 Mapper XML
+ * kiosk_run 테이블과 연동되는 MyBatis SQL 매핑 파일
+ *
+ * 주요 기능:
+ *  - 실행 세션 생성 (insertRun)
+ *  - 실행 완료 처리 (completeRun)
+ *  - 실행 취소 처리 (cancelRun)
+ *  - 단건 조회 (readRun: 회원 phone 포함)
+ *  - 목록 조회 (getRunListWithPaging: 페이징 + 조건)
+ *  - 총 개수 조회 (getTotalRunCount: 페이징 + 조건)
+ *  - 특정 키오스크 RUNNING 세션 중복 실행 여부 확인 (getRunningCountByKioskId)
+ *
+ * @author  : yukyeong
+ * @fileName: KioskRunMapper.xml
+ * @since   : 250827
+ * @history
+ *   - 250827 | yukyeong | Mapper XML 최초 생성 (insertRun, completeRun, cancelRun, readRun, getRunListWithPaging, getTotalRunCount, getRunningCountByKioskId 정의)
+ *   - 250827 | yukyeong | readRun 쿼리에서 member 테이블 LEFT JOIN 추가, phone 컬럼 매핑
+ *   - 250827 | yukyeong | 공통 WHERE 조건(kioskRunWhere) SQL 분리하여 목록/카운트 재사용
+-->
+
+
+<mapper namespace="com.petcoin.mapper.KioskRunMapper">
+
+    <resultMap id="kioskRunMap" type="com.petcoin.domain.KioskRunVO">
+        <id property="runId" column="run_id" />
+        <result property="kioskId" column="kiosk_id" />
+        <result property="memberId" column="member_id" />
+        <result property="status" column="status" />
+        <result property="startedAt" column="started_at"/>
+        <result property="endedAt" column="ended_at"/>
+    </resultMap>
+
+    <!-- 1) 실행 세션 생성 (RUNNING 상태로 시작) -->
+    <insert id="insertRun" useGeneratedKeys="true" keyProperty="runId">
+        insert into kiosk_run (
+                               kiosk_id,
+                               member_id,
+                               status,
+                               started_at,
+                               ended_at
+        ) values (
+                  #{kioskId},
+                  #{memberId},
+                  #{status},
+                  #{startedAt},
+                  #{endedAt}
+                         )
+    </insert>
+
+    <!-- 2) 실행 완료 처리 (RUNNING -> COMPLETED) -->
+    <update id="completeRun">
+        UPDATE kiosk_run
+        SET status = 'COMPLETED',
+            ended_at = #{endedAt}
+        WHERE run_id = #{runId}
+          AND status = 'RUNNING'
+    </update>
+
+    <!-- 3) 실행 취소 처리 (RUNNING -> CANCELLED) -->
+    <update id="cancelRun">
+        UPDATE kiosk_run
+        SET status = 'CANCELLED',
+            ended_at = #{endedAt}
+        WHERE run_id = #{runId}
+          AND status = 'RUNNING'
+    </update>
+
+    <!-- 4) 실행 세션 단건 조회 -->
+    <select id="readRun" resultType="com.petcoin.dto.KioskRunResponse">
+        SELECT
+            kr.run_id AS runId,
+            kr.kiosk_id AS kioskId,
+            kr.member_id AS memberId,
+            m.phone AS phone,
+            kr.status AS status,
+            kr.started_at AS startedAt,
+            kr.ended_at AS endedAt
+        FROM kiosk_run kr
+                 LEFT JOIN member m ON kr.member_id = m.member_id
+        WHERE kr.run_id = #{runId}
+    </select>
+
+    <!-- 공통 검색 조건 SQL 분리 -->
+    <sql id="kioskRunWhere">
+        <where>
+            <if test="kioskId != null"> AND kiosk_id = #{kioskId}</if>
+            <if test="status != null"> AND status = #{status}</if>
+            <if test="memberId != null"> AND member_id = #{memberId}</if>
+            <if test="startedFrom != null"> AND started_at &gt;= #{startedFrom}</if>
+            <if test="startedTo != null"> AND started_at &lt;= #{startedTo}</if>
+        </where>
+    </sql>
+
+    <!-- 5) 실행 세션 목록 조회 (페이징 + 조건) -->
+    <select id="getRunListWithPaging" parameterType="com.petcoin.dto.KioskRunCriteria" resultMap="kioskRunMap">
+        SELECT run_id, kiosk_id, member_id, status, started_at, ended_at
+        FROM kiosk_run
+        <include refid="kioskRunWhere"/>
+        ORDER BY started_at DESC
+        LIMIT #{amount} OFFSET #{offset}
+    </select>
+
+    <!-- 6) 실행 세션 총 개수 조회 -->
+    <select id="getTotalRunCount" parameterType="com.petcoin.dto.KioskRunCriteria" resultType="int">
+        SELECT COUNT(*)
+        FROM kiosk_run
+        <include refid="kioskRunWhere"/>
+    </select>
+
+    <!-- 7) 특정 키오스크 RUNNING 세션 중복 실행 여부 확인 -->
+    <select id="getRunningCountByKioskId" parameterType="long" resultType="int">
+        SELECT COUNT(*)
+        FROM kiosk_run
+        WHERE kiosk_id = #{kioskId}
+          AND status   = 'RUNNING'
+    </select>
+
+
+</mapper>

--- a/backend/petcoin/src/test/java/com/petcoin/mapper/KioskRunMapperTest.java
+++ b/backend/petcoin/src/test/java/com/petcoin/mapper/KioskRunMapperTest.java
@@ -1,0 +1,57 @@
+package com.petcoin.mapper;
+
+import com.petcoin.constant.RunStatus;
+import com.petcoin.domain.KioskRunVO;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * KioskRunMapperTest
+ * kiosk_run 테이블과 연동된 Mapper의 단위 테스트 클래스
+ *
+ * 주요 목적:
+ *  - 실행 세션 생성/완료/취소/조회 등 Mapper 동작을 검증
+ *
+ * @author  : yukyeong
+ * @fileName: KioskRunMapperTest.java
+ * @since   : 250827
+ * @history
+ *   - 250827 | yukyeong | insertRunTest 작성
+ *                        - kiosk_id=1, member_id=1 더미 데이터 기반 실행 세션 생성 검증
+ *                        - 영향받은 row 수(1) 확인
+ *                        - useGeneratedKeys 옵션에 의해 runId 자동 주입 검증
+ */
+
+@SpringBootTest
+@Slf4j
+class KioskRunMapperTest {
+
+    @Autowired
+    private KioskRunMapper kioskRunMapper;
+
+    @Test
+    @DisplayName("실행 세션 생성 테스트")
+    public void insertRunTest(){
+        // Given
+        KioskRunVO run = new KioskRunVO();
+        run.setKioskId(1L);
+        run.setMemberId(1L);
+        run.setStatus(RunStatus.RUNNING);
+        run.setStartedAt(LocalDateTime.now());
+
+        // When
+        int insert = kioskRunMapper.insertRun(run);
+
+        // Then
+        assertEquals(1, insert);
+        assertNotNull(run.getRunId());
+        log.info("new runId={}", run.getRunId());
+    }
+}


### PR DESCRIPTION
1. 테이블 수정
-- 1) 키오스크 장치 정보(kiosk)
CREATE TABLE IF NOT EXISTS kiosk (
  kiosk_id BIGINT AUTO_INCREMENT PRIMARY KEY, -- 장치 PK
  name VARCHAR(100)  NOT NULL, -- 표시명
  location VARCHAR(255)  NOT NULL, -- 설치 매장/주소
  lat DECIMAL(10,7) NULL, -- 위도
  lng DECIMAL(10,7) NULL, -- 경도
  status ENUM('ONLINE','OFFLINE','MAINT') NOT NULL DEFAULT 'OFFLINE',
  sw_version VARCHAR(50)   NULL,
  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, -- 생성 시각
  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, -- 마지막 수정 시각
  is_deleted TINYINT(1) NOT NULL DEFAULT 0 -- 소프트 삭제 (0=정상, 1=삭제)
);


2. [KioskVO] updatedAt, isDeleted 필드 추가
3. [KioskRunVO] startedAt, endedAt 필드명 수정
4. [KioskResponse] updatedAt 필드 추가


5. [KioskRunCriteria] 
실행 로그를 페이징/검색 조건으로 조회하기 위한 DTO 작성

6. [KioskRunMapper] 
DB 연동을 통해 실행 세션 생성, 상태 변경(완료/취소), 단건 조회, 목록 조회, 중복 실행 체크 등을 수행

7. [KioskRunResponse] 단건조회에서 핸드폰번호 조회를 위해 phone 추가

8. [KioskRunMapper.xml]
Mapper XML 최초 생성 (insertRun, completeRun, cancelRun, readRun, getRunListWithPaging, getTotalRunCount, getRunningCountByKioskId 정의)
readRun 쿼리에서 member 테이블 LEFT JOIN 추가, phone 컬럼 매핑
공통 WHERE 조건(kioskRunWhere) SQL 분리하여 목록/카운트 재사용

9. [KioskRunMapperTest]
(테스트코드 작성하기 전에 DB에 더미데이터 2건씩 저장 - kiosk 테이블 더미, member 테이블 더미)

insertRunTest 작성
- kiosk_id=1, member_id=1 더미 데이터 기반 실행 세션 생성 검증
- 영향받은 row 수(1) 확인
- useGeneratedKeys 옵션에 의해 runId 자동 주입 검증