### PR TITLE
[20250828] 키오스크 실행 서비스코드 작성중

### DIFF
--- a/backend/petcoin/src/main/java/com/petcoin/dto/KioskCriteria.java
+++ b/backend/petcoin/src/main/java/com/petcoin/dto/KioskCriteria.java
@@ -1,0 +1,59 @@
+package com.petcoin.dto;
+
+import com.petcoin.constant.KioskStatus;
+import com.petcoin.constant.RunStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+/*
+ * 키오스크 조회 Criteria
+ * 관리자 페이지에서 키오스크 목록을 페이징/검색 조건으로 조회하기 위한 DTO
+ *
+ * 주요 기능:
+ * - 이름/주소(keyword) 기반 검색
+ * - 상태(ONLINE / OFFLINE / MAINT) 필터링
+ * - 삭제 여부(includeDeleted) 조건 처리
+ * - 변경일자(updatedFrom ~ updatedTo) 범위 조회
+ * - 페이징(pageNum, amount, offset) 지원
+ *
+ * @author  : yukyeong
+ * @fileName: KioskCriteria
+ * @since   : 250828
+ * @history
+ *   - 250828 | yukyeong | 최초 생성 (검색 조건, 삭제여부, 날짜범위, 페이징 필드 정의 및 getOffset() 추가)
+ */
+
+@Getter @Setter
+@ToString
+public class KioskCriteria {
+
+    // 필드
+    private String keyword; // 이름,주소 검색
+    private KioskStatus status; // ONLINE,OFFLINE,MAINT 필터링
+    private Boolean includeDeleted = false; // 삭제된 키오스크 포함 여부
+    private LocalDateTime updatedFrom; // 변경일자 범위 조회 updated_at >= from
+    private LocalDateTime updatedTo; // 변경일자 범위 조회 updated_at <= to
+
+    // 페이징
+    private int pageNum; // 페이지 번호
+    private int amount; // 한 페이지에 보여줄 개수
+
+    public KioskCriteria(){
+        this(1,10);
+    }
+
+    // 원하는 페이지, 게시글 수 직접 설정
+    public KioskCriteria(int pageNum, int amount){
+        this.pageNum = pageNum;
+        this.amount = amount;
+    }
+
+    // MySQL용 offset
+    public int getOffset() {
+        return (pageNum - 1) * amount;
+    }
+
+}

--- a/backend/petcoin/src/main/java/com/petcoin/mapper/KioskMapper.java
+++ b/backend/petcoin/src/main/java/com/petcoin/mapper/KioskMapper.java
@@ -1,0 +1,69 @@
+package com.petcoin.mapper;
+
+import com.petcoin.constant.KioskStatus;
+import com.petcoin.domain.KioskVO;
+import com.petcoin.dto.KioskCriteria;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/*
+ * 키오스크 장치 Mapper 인터페이스
+ * kiosk 테이블과 연동되어 키오스크 장치의 CRUD 및 상태 전이를 관리
+ *
+ * 구분:
+ * - 관리자 페이지용 : 키오스크 등록/수정/삭제/조회 기능
+ * - 키오스크 실행용 : 키오스크 상태 전이 (예: ONLINE → RUNNING)
+ *
+ * 주요 기능:
+ * [관리자 페이지용]
+ *  - 단건 조회 (read)
+ *  - 전체 조회 (getListWithPaging, getTotalCount)
+ *  - 등록 (insert)
+ *  - 수정 (update)
+ *  - 소프트삭제 (softDelete)
+ *
+ * [키오스크 실행용]
+ *  - 상태 전이 (updateStatusIfCurrent) : 현재 상태가 from일 때만 to로 변경
+ *
+ * @author  : yukyeong
+ * @fileName: KioskMapper
+ * @since   : 250828
+ * @history
+ *   - 250828 | yukyeong | Mapper 최초 생성 (read, getListWithPaging, getTotalCount, insert, update, softDelete, transitionStatus 정의)
+ */
+
+@Mapper
+public interface KioskMapper {
+
+    // 관리자 페이지에서 키오스크 조회
+    // 1-1) 키오스크 장치 단건 조회
+    public KioskVO read(Long kioskId);
+
+    // 1-2) 키오스크 장치 전체조회 (검색 + 페이징 포함)
+    public List<KioskVO> getListWithPaging(KioskCriteria cri);
+
+    // 1-3) 키오스크 총 개수 조회
+    public int getTotalCount(KioskCriteria cri);
+
+
+    // 관리자페이지에서 키오스크 등록, 수정, 삭제
+    // 2-1) 키오스크 등록
+    public int insert(KioskVO vo); // useGeneratedKeys = true (XML에서 설정)
+
+    // 2-2) 키오스크 정보 수정
+    public int update(KioskVO vo); // 일반 정보 수정 (updated_at 갱신)
+
+    // 2-3) 키오스크 소프트삭제 (그냥 삭제하면 기존의 기록들도 함께 삭제되기 때문에 소프트삭제 사용)
+    public int softDelete(Long kioskId); // is_deleted=1
+
+
+    // 키오스크 버튼 클릭시 상태 변경
+    // 3-1) 키오스크 상태 전이 : 현재 상태가 from(현재 상태)일 때만 to(바꾸려는 목표 상태)로 변경
+    int transitionStatus(@Param("kioskId") Long kioskId,
+                              @Param("from") KioskStatus from,
+                              @Param("to") KioskStatus to);
+
+}

--- a/backend/petcoin/src/main/java/com/petcoin/mapper/KioskRunMapper.java
+++ b/backend/petcoin/src/main/java/com/petcoin/mapper/KioskRunMapper.java
@@ -11,16 +11,23 @@ import java.util.List;
 
 /*
  * 키오스크 실행 세션 Mapper 인터페이스
- * DB 연동을 통해 실행 세션 생성, 상태 변경(완료/취소), 단건 조회, 목록 조회, 중복 실행 체크 등을 수행
+ * kiosk_run 테이블과 연동되어 실행 이력(세션) 데이터를 관리
+ *
+ * 구분:
+ * - 키오스크 실행용 : 사용자가 키오스크에서 [시작/종료/취소] 버튼을 누를 때 호출
+ * - 관리자 페이지용 : 실행 이력 조회/검색/통계 등 관리 기능
  *
  * 주요 기능:
- * - 실행 세션 생성 (insertRun)
- * - 실행 세션 단건 조회 (readRun)
- * - 실행 세션 목록 조회 (getRunListWithPaging)
- * - 실행 세션 총 개수 조회 (getTotalRunCount)
- * - 실행 완료 처리 (completeRun)
- * - 실행 취소 처리 (cancelRun)
- * - 특정 키오스크 RUNNING 세션 존재 여부 확인 (getRunningCountByKioskId)
+ * [키오스크 실행용]
+ *  - 실행 세션 생성 (insertRun) → RUNNING 상태 시작
+ *  - 실행 완료 처리 (completeRun) → RUNNING → COMPLETED
+ *  - 실행 취소 처리 (cancelRun)   → RUNNING → CANCELLED
+ *  - 특정 키오스크 RUNNING 세션 개수 확인 (getRunningCountByKioskId) → 중복 실행 방지
+ *
+ * [관리자 페이지용]
+ *  - 실행 세션 단건 조회 (readRun: phone 포함)
+ *  - 실행 세션 목록 조회 (getRunListWithPaging: 페이징 + 조건 검색)
+ *  - 실행 세션 총 개수 조회 (getTotalRunCount)
  *
  * @author  : yukyeong
  * @fileName: KioskRunMapper
@@ -32,26 +39,29 @@ import java.util.List;
 @Mapper
 public interface KioskRunMapper {
 
-    // 1) 실행 세션 생성 (RUNNING 상태로 시작)
+    // 키오스크 실행용
+    // 1-1) 실행 세션 생성 (RUNNING 상태로 시작)
     public int insertRun(KioskRunVO vo); // useGeneratedKeys로 runId 채움
 
-    // 2) 실행 완료 처리 (RUNNING -> COMPLETED)
+    // 1-2) 실행 완료 처리 (RUNNING -> COMPLETED)
     public int completeRun(@Param("runId") Long runId,
                            @Param("endedAt")LocalDateTime endedAt);
 
-    // 3) 실행 취소 처리 (RUNNING -> CANCELLED)
+    // 1-3) 실행 취소 처리 (RUNNING -> CANCELLED)
     public int cancelRun(@Param("runId") Long runId,
-                  @Param("endedAt") LocalDateTime endedAt);
+                         @Param("endedAt") LocalDateTime endedAt);
 
-    // 4) 실행 세션 단건 조회 (단건 조회는 phone 포함 DTO로 반환)
+    // 1-4) 특정 키오스크 RUNNING 세션 중복 실행 여부 확인
+    public int getRunningCountByKioskId(@Param("kioskId") Long kioskId);
+
+    // 관리자 페이지용
+    // 2-1) 실행 세션 단건 조회 (단건 조회는 phone 포함 DTO로 반환)
     public KioskRunResponse readRun(Long runId);
 
-    // 5) 실행 세션 목록 조회 (페이징 + 조건)
+    // 2-2) 실행 세션 목록 조회 (페이징 + 조건)
     public List<KioskRunVO> getRunListWithPaging(KioskRunCriteria cri);
 
-    // 6) 실행 세션 총 개수 조회 (페이징 + 조건)
+    // 2-3) 실행 세션 총 개수 조회
     public int getTotalRunCount(KioskRunCriteria cri);
 
-    // 7) 특정 키오스크 RUNNING 세션 중복 실행 여부 확인
-    public int getRunningCountByKioskId(Long kioskId);
 }

--- a/backend/petcoin/src/main/java/com/petcoin/service/KioskRunService.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/KioskRunService.java
@@ -1,0 +1,20 @@
+package com.petcoin.service;
+
+import com.petcoin.dto.KioskRunEndRequest;
+import com.petcoin.dto.KioskRunResponse;
+import com.petcoin.dto.KioskRunStartRequest;
+
+public interface KioskRunService {
+
+    // 실행 시작 : 키오스크가 ONLINE이고, 해당 키오스크에 RUNNING 세션이 없어야 함
+    KioskRunResponse startRun(KioskRunStartRequest request);
+
+
+    // 실행 종료 : RUNNING → COMPLETED 전이만 허용
+    KioskRunResponse endRun(KioskRunEndRequest request);
+
+
+    // 실행 취소 : RUNNING → CANCELLED 전이만 허용
+    KioskRunResponse cancleRun(KioskRunEndRequest request);
+
+}

--- a/backend/petcoin/src/main/java/com/petcoin/service/KioskRunServiceImpl.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/KioskRunServiceImpl.java
@@ -1,0 +1,62 @@
+//package com.petcoin.service;
+//
+//import com.petcoin.constant.KioskStatus;
+//import com.petcoin.constant.RunStatus;
+//import com.petcoin.domain.KioskRunVO;
+//import com.petcoin.dto.KioskRunEndRequest;
+//import com.petcoin.dto.KioskRunResponse;
+//import com.petcoin.dto.KioskRunStartRequest;
+//import com.petcoin.mapper.KioskMapper;
+//import com.petcoin.mapper.KioskRunMapper;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import java.time.LocalDateTime;
+//
+//@Service
+//@Slf4j
+//@RequiredArgsConstructor
+//public class KioskRunServiceImpl implements KioskRunService{
+//
+//    private final KioskMapper kioskMapper; // 키오스크 상태 조회용 (ONLINE 여부)
+//    private final KioskRunMapper kioskRunMapper;   // 실행 세션 insert/update
+//
+//    // KioskRunServiceImpl 내부
+//    private KioskRunVO dtoToVo(KioskRunStartRequest dto) {
+//        KioskRunVO vo = new KioskRunVO();
+//        vo.setKioskId(dto.getKioskId());
+//        vo.setMemberId(dto.getMemberId());
+//        vo.setStatus(RunStatus.RUNNING); // 시작 시 고정
+//        vo.setStartedAt(LocalDateTime.now());
+//        return vo;
+//    }
+//
+//    private KioskRunResponse voToDto(KioskRunVO vo) {
+//        KioskRunResponse dto = new KioskRunResponse();
+//        dto.setRunId(vo.getRunId());
+//        dto.setKioskId(vo.getKioskId());
+//        dto.setMemberId(vo.getMemberId());
+//        dto.setStatus(vo.getStatus());
+//        dto.setStartedAt(vo.getStartedAt());
+//        dto.setEndedAt(vo.getEndedAt());
+//        return dto;
+//    }
+//
+//    @Override
+//    @Transactional
+//    public KioskRunResponse startRun(KioskRunStartRequest req){
+//
+//    }
+//
+//    @Override
+//    @Transactional
+//    public KioskRunResponse endRun(KioskRunEndRequest req){
+//
+//    }
+//
+//    @Transactional
+//    public KioskRunResponse cancelRun(KioskRunEndRequest req){
+//    }
+//}

--- a/backend/petcoin/src/main/resources/mapper/KioskMapper.xml
+++ b/backend/petcoin/src/main/resources/mapper/KioskMapper.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+ * KioskMapper.xml
+ * kiosk 테이블과 연동되는 MyBatis SQL 매핑 파일
+ *
+ * 주요 기능:
+ * [관리자 페이지용]
+ *  - 단건 조회 (read)
+ *  - 전체 조회 (getListWithPaging, getTotalCount)
+ *  - 등록 (insert)
+ *  - 수정 (update)
+ *  - 소프트삭제 (softDelete)
+ *
+ * [키오스크 실행용]
+ *  - 상태 전이 (transitionStatus) : 현재 상태가 from일 때만 to로 변경
+ *
+ * @author  : yukyeong
+ * @fileName: KioskMapper.xml
+ * @since   : 250828
+ * @history
+ *   - 250828 | yukyeong | 최초 생성 (resultMap, 공통 WHERE, read, getListWithPaging, getTotalCount, insert, update, softDelete, transitionStatus 정의)
+ *   - 250828 | yukyeong | insert/update에서 status 컬럼 제거 (DB 기본값/전용 전이 쿼리로 일원화)
+ *
+-->
+
+
+<mapper namespace="com.petcoin.mapper.KioskMapper">
+    <resultMap id="kioskMap" type="com.petcoin.domain.KioskVO">
+        <id property="kioskId" column="kiosk_id"/>
+        <result property="name" column="name"/>
+        <result property="location" column="location"/>
+        <result property="lat" column="lat"/>
+        <result property="lng" column="lng"/>
+        <result property="status" column="status"/>
+        <result property="swVersion" column="sw_version"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+        <result property="isDeleted" column="is_deleted"/>
+    </resultMap>
+
+
+
+    <!-- 1-1) 단건 조회 -->
+    <select id="read" resultMap="kioskMap">
+        SELECT kiosk_id, name, location, lat, lng, status, sw_version, created_at, updated_at, is_deleted
+        FROM kiosk
+        WHERE kiosk_id = #{kioskId}
+          AND is_deleted = 0
+    </select>
+
+    <!-- 공통 조건 SQL 분리-->
+    <sql id="kioskWhere">
+        <where>
+            <if test="keyword != null and keyword != ''">
+                AND (name LIKE CONCAT('%', #{keyword}, '%')
+                OR location LIKE CONCAT('%', #{keyword}, '%'))
+            </if>
+            <if test="status != null">AND status = #{status}</if>
+            <if test="includeDeleted == null or includeDeleted == false">AND is_deleted = 0</if>
+            <if test="updatedFrom != null">AND updated_at &gt;= #{updatedFrom}</if>
+            <if test="updatedTo != null">AND updated_at &lt;= #{updatedTo}</if>
+        </where>
+    </sql>
+
+    <!-- 1-2) 전체 조회 (페이징 + 검색) -->
+    <select id="getListWithPaging" parameterType="com.petcoin.dto.KioskCriteria" resultMap="kioskMap">
+        SELECT kiosk_id, name, location, lat, lng, status, sw_version, created_at, updated_at, is_deleted
+        FROM kiosk
+        <include refid="kioskWhere"/>
+        ORDER BY updated_at DESC
+        LIMIT #{amount} OFFSET #{offset}
+    </select>
+
+
+    <!-- 1-3) 총 개수 조회 -->
+    <select id="getTotalCount" parameterType="com.petcoin.dto.KioskCriteria" resultType="int">
+        SELECT COUNT(*)
+        FROM kiosk
+        <include refid="kioskWhere"/>
+    </select>
+
+
+    <!-- 2-1) 등록 -->
+    <insert id="insert" useGeneratedKeys="true" keyProperty="kioskId">
+        INSERT INTO kiosk (name, location, lat, lng, sw_version, created_at, updated_at, is_deleted)
+        VALUES (#{name}, #{location}, #{lat}, #{lng}, #{swVersion}, NOW(), NOW(), 0)
+    </insert>
+
+
+    <!-- 2-2) 수정 -->
+    <update id="update">
+        UPDATE kiosk
+        SET name = #{name},
+            location = #{location},
+            lat = #{lat},
+            lng = #{lng},
+            sw_version = #{swVersion},
+            updated_at = NOW()
+        WHERE kiosk_id = #{kioskId}
+          AND is_deleted = 0
+    </update>
+
+
+    <!-- 2-3) 소프트 삭제 -->
+    <update id="softDelete">
+        UPDATE kiosk
+        SET is_deleted = 1,
+            updated_at = NOW()
+        WHERE kiosk_id = #{kioskId}
+          AND is_deleted = 0
+    </update>
+
+
+    <!-- 3-1) 상태 전이 -->
+    <update id="transitionStatus">
+        UPDATE kiosk
+        SET status = #{to},
+            updated_at = NOW()
+        WHERE kiosk_id = #{kioskId}
+          AND status = #{from}
+          AND is_deleted = 0
+    </update>
+
+</mapper>

--- a/backend/petcoin/src/main/resources/mapper/KioskRunMapper.xml
+++ b/backend/petcoin/src/main/resources/mapper/KioskRunMapper.xml
@@ -37,7 +37,7 @@
         <result property="endedAt" column="ended_at"/>
     </resultMap>
 
-    <!-- 1) 실행 세션 생성 (RUNNING 상태로 시작) -->
+    <!-- 1-1) 실행 세션 생성 (RUNNING 상태로 시작) -->
     <insert id="insertRun" useGeneratedKeys="true" keyProperty="runId">
         insert into kiosk_run (
                                kiosk_id,
@@ -54,7 +54,7 @@
                          )
     </insert>
 
-    <!-- 2) 실행 완료 처리 (RUNNING -> COMPLETED) -->
+    <!-- 1-2) 실행 완료 처리 (RUNNING -> COMPLETED) -->
     <update id="completeRun">
         UPDATE kiosk_run
         SET status = 'COMPLETED',
@@ -63,7 +63,7 @@
           AND status = 'RUNNING'
     </update>
 
-    <!-- 3) 실행 취소 처리 (RUNNING -> CANCELLED) -->
+    <!-- 1-3) 실행 취소 처리 (RUNNING -> CANCELLED) -->
     <update id="cancelRun">
         UPDATE kiosk_run
         SET status = 'CANCELLED',
@@ -72,7 +72,15 @@
           AND status = 'RUNNING'
     </update>
 
-    <!-- 4) 실행 세션 단건 조회 -->
+    <!-- 1-4) 특정 키오스크 RUNNING 세션 중복 실행 여부 확인 -->
+    <select id="getRunningCountByKioskId" parameterType="long" resultType="int">
+        SELECT COUNT(*)
+        FROM kiosk_run
+        WHERE kiosk_id = #{kioskId}
+          AND status   = 'RUNNING'
+    </select>
+
+    <!-- 2-1) 실행 세션 단건 조회 -->
     <select id="readRun" resultType="com.petcoin.dto.KioskRunResponse">
         SELECT
             kr.run_id AS runId,
@@ -98,7 +106,7 @@
         </where>
     </sql>
 
-    <!-- 5) 실행 세션 목록 조회 (페이징 + 조건) -->
+    <!-- 2-2) 실행 세션 목록 조회 (페이징 + 조건) -->
     <select id="getRunListWithPaging" parameterType="com.petcoin.dto.KioskRunCriteria" resultMap="kioskRunMap">
         SELECT run_id, kiosk_id, member_id, status, started_at, ended_at
         FROM kiosk_run
@@ -107,20 +115,14 @@
         LIMIT #{amount} OFFSET #{offset}
     </select>
 
-    <!-- 6) 실행 세션 총 개수 조회 -->
+    <!-- 2-3) 실행 세션 총 개수 조회 -->
     <select id="getTotalRunCount" parameterType="com.petcoin.dto.KioskRunCriteria" resultType="int">
         SELECT COUNT(*)
         FROM kiosk_run
         <include refid="kioskRunWhere"/>
     </select>
 
-    <!-- 7) 특정 키오스크 RUNNING 세션 중복 실행 여부 확인 -->
-    <select id="getRunningCountByKioskId" parameterType="long" resultType="int">
-        SELECT COUNT(*)
-        FROM kiosk_run
-        WHERE kiosk_id = #{kioskId}
-          AND status   = 'RUNNING'
-    </select>
+
 
 
 </mapper>

--- a/backend/petcoin/src/test/java/com/petcoin/mapper/KioskMapperTest.java
+++ b/backend/petcoin/src/test/java/com/petcoin/mapper/KioskMapperTest.java
@@ -1,0 +1,126 @@
+package com.petcoin.mapper;
+
+import com.petcoin.constant.KioskStatus;
+import com.petcoin.domain.KioskVO;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * KioskMapperTest
+ * kiosk 테이블과 연동된 KioskMapper의 단위 테스트 클래스
+ *
+ * 주요 목적:
+ *  - 키오스크 상태 전이(transitionStatus) 로직이 올바르게 동작하는지 검증
+ *  - 전이 성공/실패/소프트삭제 케이스까지 포함해 예외 상황을 확인
+ *
+ * @author  : yukyeong
+ * @fileName: KioskMapperTest.java
+ * @since   : 250828
+ * @history
+ *   - 250828 | yukyeong | transitionStatus_success 작성
+ *                        - 신규 키오스크 등록 후 ONLINE → OFFLINE 정상 전이 확인
+ *                        - updated=1, 상태 변경 확인
+ *   - 250828 | yukyeong | transitionStatus_fail 작성
+ *                        - 잘못된 from 상태를 넣고 전이 시도
+ *                        - updated=0, 실제 상태 유지 확인
+ *   - 250828 | yukyeong | transitionStatus_fail2 작성
+ *                        - 소프트삭제된 키오스크에 대해 전이 시도
+ *                        - updated=0, read 결과 null 확인
+ */
+
+@SpringBootTest
+@Slf4j
+class KioskMapperTest {
+
+    @Autowired
+    private KioskMapper kioskMapper;
+
+    @Test
+    @Transactional
+    @DisplayName("상태전이 성공 테스트 - ONLINE -> OFFLINE")
+    public void transitionStatus_success() {
+        // Given : 신규 키오스크 등록
+        KioskVO kiosk = KioskVO.builder()
+                .name("테스트1")
+                .location("서울 강동구")
+                .lat(37.5)
+                .lng(127.1)
+                .swVersion("v1.0")
+                .build();
+        kioskMapper.insert(kiosk);
+
+        // When : OFFLINE → ONLINE 전이 시도
+        int updated = kioskMapper.transitionStatus(kiosk.getKioskId(),
+                KioskStatus.ONLINE, KioskStatus.OFFLINE);
+
+        // Then : 성공 (updated=1) + 상태가 ONLINE으로 변경됨 확인
+        assertEquals(1, updated);
+        KioskVO result = kioskMapper.read(kiosk.getKioskId());
+        assertEquals(KioskStatus.OFFLINE, result.getStatus());
+        log.info("전이 성공: {} -> {}", KioskStatus.ONLINE, result.getStatus());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("상태 전이 실패 테스트 - 잘못된 from을 넣고 전이시도")
+    public void transitionStatus_fail() {
+        // Given : 신규 키오스크 등록
+        KioskVO kiosk = KioskVO.builder()
+                .name("테스트2")
+                .location("서울 강동구")
+                .lat(37.5)
+                .lng(127.1)
+                .swVersion("v1.0")
+                .build();
+        kioskMapper.insert(kiosk);
+
+        // When : ONLINE인데, from을 OFFLINE으로 가정하고 MAINT로 전이 시도
+        int updated = kioskMapper.transitionStatus(
+                kiosk.getKioskId(),
+                KioskStatus.OFFLINE, // 잘못된 from(현재 상태와 불일치)
+                KioskStatus.MAINT // 목표 상태
+        );
+
+        // Then: 전이 실패(updated=0) + 실제 상태는 그대로 ONLINE
+        assertEquals(0, updated);
+        KioskVO result = kioskMapper.read(kiosk.getKioskId());
+        assertEquals(KioskStatus.ONLINE, result.getStatus());
+        log.info("전이 실패: updated={} 현재 상태={}", updated, result.getStatus());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("상태전이 실패 테스트2 - 소프트삭제된 키오스크 전이 불가")
+    public void transitionStatus_fail2() {
+        // Given : 신규 키오스크 등록후 소프트삭제
+        KioskVO kiosk = KioskVO.builder()
+                .name("테스트3")
+                .location("서울시 강서구")
+                .lat(37.5)
+                .lng(127.1)
+                .swVersion("v1.0")
+                .build();
+        kioskMapper.insert(kiosk);
+        kioskMapper.softDelete(kiosk.getKioskId()); // is_deleted=1
+
+        // When: ONLINE -> OFFLINE 전이 시도
+        int updated = kioskMapper.transitionStatus(
+                kiosk.getKioskId(),
+                KioskStatus.ONLINE,
+                KioskStatus.OFFLINE
+        );
+
+        // Then: 전이 실패(updated=0). (read는 is_deleted=0 조건이 있어 null일 수도 있음)
+        assertEquals(0, updated);
+        KioskVO result = kioskMapper.read(kiosk.getKioskId()); // 단건조회에서는 null값이 나와야함
+        assertNull(result);
+        log.info("전이 실패: updated={} 조회 결과={}", updated, result);
+
+    }
+}

--- a/backend/petcoin/src/test/java/com/petcoin/mapper/KioskRunMapperTest.java
+++ b/backend/petcoin/src/test/java/com/petcoin/mapper/KioskRunMapperTest.java
@@ -2,11 +2,13 @@ package com.petcoin.mapper;
 
 import com.petcoin.constant.RunStatus;
 import com.petcoin.domain.KioskRunVO;
+import com.petcoin.dto.KioskRunResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -27,6 +29,17 @@ import static org.junit.jupiter.api.Assertions.*;
  *                        - kiosk_id=1, member_id=1 더미 데이터 기반 실행 세션 생성 검증
  *                        - 영향받은 row 수(1) 확인
  *                        - useGeneratedKeys 옵션에 의해 runId 자동 주입 검증
+ *   - 250828 | yukyeong | completeRunTest 작성
+ *                        - 실행 중 세션(RUNNING) → 실행 완료(COMPLETED) 상태 전환 검증
+ *                        - update 영향 행 수(1) 확인 및 readRun 결과 상태 확인
+ *   - 250828 | yukyeong | cancelRunTest 작성
+ *                        - 실행 중 세션(RUNNING) → 실행 취소(CANCELLED) 상태 전환 검증
+ *                        - update 영향 행 수(1) 확인 및 readRun 결과 상태 확인
+ *   - 250828 | yukyeong | getRunningCountByKioskIdTest 작성
+ *                        - kiosk_id=1에 RUNNING 세션을 2개 추가 생성
+ *                        - 기존 DB에 남아있던 RUNNING 1개 포함, 총 3개 집계되는지 확인
+ *                        - 중복 실행 방지 로직 적용 전 카운트 확인용
+ *
  */
 
 @SpringBootTest
@@ -53,5 +66,80 @@ class KioskRunMapperTest {
         assertEquals(1, insert);
         assertNotNull(run.getRunId());
         log.info("new runId={}", run.getRunId());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("실행 완료 처리 테스트")
+    public void completeRunTest(){
+
+        // Given
+        KioskRunVO run = new KioskRunVO();
+        run.setKioskId(1L);
+        run.setMemberId(1L);
+        run.setStatus(RunStatus.RUNNING);
+        run.setStartedAt(LocalDateTime.now());
+        kioskRunMapper.insertRun(run); // DB에 INSERT → runId가 자동 생성됨
+
+        // When
+        run.setEndedAt(LocalDateTime.now());
+        int update = kioskRunMapper.completeRun(run.getRunId(), run.getEndedAt());
+
+        // Then
+        assertEquals(1, update);
+        KioskRunResponse completed = kioskRunMapper.readRun(run.getRunId());
+        assertEquals(RunStatus.COMPLETED, completed.getStatus()); // runId의 상태를 RUNNING → COMPLETED로 업데이트
+        log.info("completed runId={} status={}", run.getRunId(), completed.getStatus());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("실행 처리 취소 테스트")
+    public void cancelRunTest(){
+
+        // Given
+        KioskRunVO run = new KioskRunVO();
+        run.setKioskId(1L);
+        run.setMemberId(1L);
+        run.setStatus(RunStatus.RUNNING);
+        run.setStartedAt(LocalDateTime.now());
+        kioskRunMapper.insertRun(run); // DB에 INSERT → runId가 자동 생성됨
+
+        // When
+        run.setEndedAt(LocalDateTime.now());
+        int update = kioskRunMapper.cancelRun(run.getRunId(), run.getEndedAt());
+
+        // Then
+        assertEquals(1, update);
+        KioskRunResponse cancelled = kioskRunMapper.readRun(run.getRunId());
+        assertEquals(RunStatus.CANCELLED, cancelled.getStatus()); // runId의 상태를 RUNNING → CANCELLED로 업데이트
+        log.info("cancelled runId={} status={}", run.getRunId(), cancelled.getStatus());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("키오스트 RUNNING 세션 중복 실행 시 카운트 값이 정확히 집계되는지 확인 테스트")
+    public void getRunningCountByKioskIdTest() {
+        // Given: kiosk_id=1에서 RUNNING 상태 세션을 2개 생성
+        KioskRunVO run1 = new KioskRunVO();
+        run1.setKioskId(1L);
+        run1.setMemberId(1L);
+        run1.setStatus(RunStatus.RUNNING);
+        run1.setStartedAt(LocalDateTime.now());
+        kioskRunMapper.insertRun(run1);
+
+        KioskRunVO run2 = new KioskRunVO();
+        run2.setKioskId(1L);
+        run2.setMemberId(2L);
+        run2.setStatus(RunStatus.RUNNING);
+        run2.setStartedAt(LocalDateTime.now());
+        kioskRunMapper.insertRun(run2);
+
+        // When: kiosk_id=1에서 RUNNING 세션 개수 조회
+        int runningCount = kioskRunMapper.getRunningCountByKioskId(1L);
+
+        // Then: 3개가 조회되어야 함 (기존에 있던거 + 방금 만든 2개)
+        assertEquals(3, runningCount);
+        log.info("kioskId=1 runningCount={}", runningCount);
     }
 }


### PR DESCRIPTION
[KioskRunMapperTest]
completeRunTest 작성
- 실행 중 세션(RUNNING) → 실행 완료(COMPLETED) 상태 전환 검증
- update 영향 행 수(1) 확인 및 readRun 결과 상태 확인
cancelRunTest 작성
- 실행 중 세션(RUNNING) → 실행 취소(CANCELLED) 상태 전환 검증
- update 영향 행 수(1) 확인 및 readRun 결과 상태 확인
getRunningCountByKioskIdTest 작성
- kiosk_id=1에 RUNNING 세션을 2개 추가 생성
- 기존 DB에 남아있던 RUNNING 1개 포함, 총 3개 집계되는지 확인
- 중복 실행 방지 로직 적용 전 카운트 확인용

[KioskCriteria]
관리자 페이지에서 키오스크 목록을 페이징/검색 조건으로 조회하기 위한 DTO

[KioskMapper]
Mapper 최초 생성 (read, getListWithPaging, getTotalCount, insert, update, softDelete, transitionStatus 정의)

[KioskMapper.xml]
최초 생성 (resultMap, 공통 WHERE, read, getListWithPaging, getTotalCount, insert, update, softDelete, transitionStatus 정의)
insert/update에서 status 컬럼 제거 (DB 기본값/전용 전이 쿼리로 일원화)

[KioskMapperTest]
transitionStatus_success 작성
- 신규 키오스크 등록 후 ONLINE → OFFLINE 정상 전이 확인
- updated=1, 상태 변경 확인
transitionStatus_fail 작성
- 잘못된 from 상태를 넣고 전이 시도
- updated=0, 실제 상태 유지 확인
transitionStatus_fail2 작성
- 소프트삭제된 키오스크에 대해 전이 시도
- updated=0, read 결과 null 확인

[KioskRunService]
키오스크 실행 이력(kiosk_run)의 생성/완료/취소에 대한 도메인 규칙(상태 전이) 제공

