### PR TITLE
[20250829] 키오스크 세션 로직 구현중

### DIFF
--- a/DB 정리.txt
+++ b/DB 정리.txt
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS kiosk (
   location VARCHAR(255)  NOT NULL, -- 설치 매장/주소
   lat DECIMAL(10,7) NULL, -- 위도
   lng DECIMAL(10,7) NULL, -- 경도
-  status ENUM('ONLINE','OFFLINE','MAINT') NOT NULL DEFAULT 'OFFLINE',
+  status ENUM('ONLINE','OFFLINE','MAINT') NOT NULL DEFAULT 'ONLINE',
   sw_version VARCHAR(50)   NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, -- 생성 시각
   updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, -- 마지막 수정 시각
@@ -86,3 +86,11 @@ CREATE TABLE IF NOT EXISTS kiosk_run (
   FOREIGN KEY (kiosk_id) REFERENCES kiosk(kiosk_id),
   FOREIGN KEY (member_id) REFERENCES member(member_id)
 );
+
+CREATE INDEX idx_kiosk_run_kiosk_id ON kiosk_run(kiosk_id);
+
+-- RUNNING 여부 체크/범위잠금 정확도 ↑
+CREATE INDEX idx_kiosk_run_kiosk_status ON kiosk_run (kiosk_id, status);
+
+-- 목록 조회에서 최근순 정렬도 자주 쓰면 같이(선택)
+CREATE INDEX idx_kiosk_run_kiosk_status_started ON kiosk_run (kiosk_id, status, started_at DESC);

--- a/backend/petcoin/src/main/java/com/petcoin/controller/KioskRunApiController.java
+++ b/backend/petcoin/src/main/java/com/petcoin/controller/KioskRunApiController.java
@@ -1,0 +1,10 @@
+//package com.petcoin.controller;
+//
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//@RestController
+//@RequestMapping("/api/kiosk-runs")
+//public class KioskRunApiController {
+//
+//}

--- a/backend/petcoin/src/main/java/com/petcoin/mapper/KioskMapper.java
+++ b/backend/petcoin/src/main/java/com/petcoin/mapper/KioskMapper.java
@@ -27,12 +27,14 @@ import java.util.List;
  *
  * [키오스크 실행용]
  *  - 상태 전이 (updateStatusIfCurrent) : 현재 상태가 from일 때만 to로 변경
+ *  - 현재 상태 단건 조회 (findStatusById) : 온라인 여부 확인용
  *
  * @author  : yukyeong
  * @fileName: KioskMapper
  * @since   : 250828
  * @history
  *   - 250828 | yukyeong | Mapper 최초 생성 (read, getListWithPaging, getTotalCount, insert, update, softDelete, transitionStatus 정의)
+ *   - 250829 | yukyeong | findStatusById 추가 (키오스크 ONLINE 여부 확인용), lockKioskRow 추가 (행 잠금: startRun 시 동시 실행 방지용)
  */
 
 @Mapper
@@ -62,8 +64,15 @@ public interface KioskMapper {
 
     // 키오스크 버튼 클릭시 상태 변경
     // 3-1) 키오스크 상태 전이 : 현재 상태가 from(현재 상태)일 때만 to(바꾸려는 목표 상태)로 변경
-    int transitionStatus(@Param("kioskId") Long kioskId,
+    public int transitionStatus(@Param("kioskId") Long kioskId,
                               @Param("from") KioskStatus from,
                               @Param("to") KioskStatus to);
 
+
+    // 3-2) 키오스크 현재 상태 조회 (ONLINE 여부 확인용)
+    public KioskStatus findStatusById(Long kioskId);
+
+
+    // 3-3) 행 잠금: 시작 동시성 제어용
+    public KioskVO lockKioskRow(Long kioskId);
 }

--- a/backend/petcoin/src/main/java/com/petcoin/mapper/KioskRunMapper.java
+++ b/backend/petcoin/src/main/java/com/petcoin/mapper/KioskRunMapper.java
@@ -34,6 +34,7 @@ import java.util.List;
  * @since   : 250827
  * @history
  *   - 250827 | yukyeong | Mapper 최초 생성 (insertRun, completeRun, cancelRun, readRun, getRunListWithPaging, getTotalRunCount, getRunningCountByKioskId 메서드 정의)
+ *   - 250829 | yukyeong | lockRunRow 추가 (행 잠금: endRun/cancelRun 시 동시성 제어), readRunAsVO 추가 (실행 로직용 VO 반환, DB DEFAULT/트리거 값 반영 확인용)
  */
 
 @Mapper
@@ -52,7 +53,13 @@ public interface KioskRunMapper {
                          @Param("endedAt") LocalDateTime endedAt);
 
     // 1-4) 특정 키오스크 RUNNING 세션 중복 실행 여부 확인
-    public int getRunningCountByKioskId(@Param("kioskId") Long kioskId);
+    public int getRunningCountByKioskId(Long kioskId);
+
+    // 1-5) 실행 세션 행 잠금 (종료/취소 시 동시성 제어)
+    public KioskRunVO lockRunRow(Long runId);
+
+    // 1-6) 실행 세션 단건 조회 (실행 로직용: VO 반환, DB DEFAULT/트리거 반영값 확인용)
+    public KioskRunVO readRunAsVO(Long runId);
 
     // 관리자 페이지용
     // 2-1) 실행 세션 단건 조회 (단건 조회는 phone 포함 DTO로 반환)

--- a/backend/petcoin/src/main/java/com/petcoin/service/KioskRunService.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/KioskRunService.java
@@ -4,17 +4,34 @@ import com.petcoin.dto.KioskRunEndRequest;
 import com.petcoin.dto.KioskRunResponse;
 import com.petcoin.dto.KioskRunStartRequest;
 
+/*
+ * 키오스크 실행 세션 Service 인터페이스
+ * - 키오스크에서 실행 시작/종료/취소 버튼 동작 시 호출되는 비즈니스 로직 규격을 정의
+ * - 구현체: KioskRunServiceImpl
+ *
+ * 주요 기능:
+ *  - startRun : 키오스크가 ONLINE 상태일 때 실행 세션 생성 (RUNNING 시작)
+ *  - endRun   : RUNNING → COMPLETED 전이만 허용
+ *  - cancelRun: RUNNING → CANCELLED 전이만 허용
+ *
+ * @author  : yukyeong
+ * @fileName: KioskRunService
+ * @since   : 250827
+ * @history
+ *   - 250827 | yukyeong | 인터페이스 최초 생성 (startRun, endRun, cancelRun 메서드 정의)
+ */
+
 public interface KioskRunService {
 
     // 실행 시작 : 키오스크가 ONLINE이고, 해당 키오스크에 RUNNING 세션이 없어야 함
-    KioskRunResponse startRun(KioskRunStartRequest request);
+    KioskRunResponse startRun(KioskRunStartRequest req);
 
 
     // 실행 종료 : RUNNING → COMPLETED 전이만 허용
-    KioskRunResponse endRun(KioskRunEndRequest request);
+    KioskRunResponse endRun(KioskRunEndRequest req);
 
 
     // 실행 취소 : RUNNING → CANCELLED 전이만 허용
-    KioskRunResponse cancleRun(KioskRunEndRequest request);
+    KioskRunResponse cancelRun(KioskRunEndRequest req);
 
 }

--- a/backend/petcoin/src/main/java/com/petcoin/service/KioskRunServiceImpl.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/KioskRunServiceImpl.java
@@ -1,62 +1,162 @@
-//package com.petcoin.service;
-//
-//import com.petcoin.constant.KioskStatus;
-//import com.petcoin.constant.RunStatus;
-//import com.petcoin.domain.KioskRunVO;
-//import com.petcoin.dto.KioskRunEndRequest;
-//import com.petcoin.dto.KioskRunResponse;
-//import com.petcoin.dto.KioskRunStartRequest;
-//import com.petcoin.mapper.KioskMapper;
-//import com.petcoin.mapper.KioskRunMapper;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import java.time.LocalDateTime;
-//
-//@Service
-//@Slf4j
-//@RequiredArgsConstructor
-//public class KioskRunServiceImpl implements KioskRunService{
-//
-//    private final KioskMapper kioskMapper; // 키오스크 상태 조회용 (ONLINE 여부)
-//    private final KioskRunMapper kioskRunMapper;   // 실행 세션 insert/update
-//
-//    // KioskRunServiceImpl 내부
-//    private KioskRunVO dtoToVo(KioskRunStartRequest dto) {
-//        KioskRunVO vo = new KioskRunVO();
-//        vo.setKioskId(dto.getKioskId());
-//        vo.setMemberId(dto.getMemberId());
-//        vo.setStatus(RunStatus.RUNNING); // 시작 시 고정
-//        vo.setStartedAt(LocalDateTime.now());
-//        return vo;
-//    }
-//
-//    private KioskRunResponse voToDto(KioskRunVO vo) {
-//        KioskRunResponse dto = new KioskRunResponse();
-//        dto.setRunId(vo.getRunId());
-//        dto.setKioskId(vo.getKioskId());
-//        dto.setMemberId(vo.getMemberId());
-//        dto.setStatus(vo.getStatus());
-//        dto.setStartedAt(vo.getStartedAt());
-//        dto.setEndedAt(vo.getEndedAt());
-//        return dto;
-//    }
-//
-//    @Override
-//    @Transactional
-//    public KioskRunResponse startRun(KioskRunStartRequest req){
-//
-//    }
-//
-//    @Override
-//    @Transactional
-//    public KioskRunResponse endRun(KioskRunEndRequest req){
-//
-//    }
-//
-//    @Transactional
-//    public KioskRunResponse cancelRun(KioskRunEndRequest req){
-//    }
-//}
+package com.petcoin.service;
+
+import com.petcoin.constant.KioskStatus;
+import com.petcoin.constant.RunStatus;
+import com.petcoin.domain.KioskRunVO;
+import com.petcoin.dto.KioskRunEndRequest;
+import com.petcoin.dto.KioskRunResponse;
+import com.petcoin.dto.KioskRunStartRequest;
+import com.petcoin.mapper.KioskMapper;
+import com.petcoin.mapper.KioskRunMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/*
+ * 키오스크 실행 세션 Service 구현체
+ * - KioskRunService 인터페이스 구현
+ * - 실행 시작/종료/취소 비즈니스 로직 처리 및 동시성 제어
+ *
+ * 주요 기능:
+ *  - startRun  : 키오스크 ONLINE 확인 → RUNNING 중복 체크 → 세션 시작
+ *  - endRun    : RUNNING 상태만 COMPLETED 전이, 멱등 처리
+ *  - cancelRun : RUNNING 상태만 CANCELLED 전이, 멱등 처리
+ *
+ * 동시성 제어:
+ *  - startRun  → kioskMapper.lockKioskRow(kioskId) 사용
+ *  - endRun/cancelRun → kioskRunMapper.lockRunRow(runId) 사용
+ *
+ * @author  : yukyeong
+ * @fileName: KioskRunServiceImpl
+ * @since   : 250827
+ * @history
+ *   - 250827 | yukyeong | ServiceImpl 최초 생성 (dtoToVo, voToDto, startRun 기본 로직 구현)
+ *   - 250829 | yukyeong | endRun, cancelRun 메서드 추가 (RUNNING 상태 조건부 전이, 멱등 처리 포함)
+ *   - 250829 | yukyeong | 행 잠금(lockKioskRow, lockRunRow) 적용하여 동시성 제어 보강
+ */
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class KioskRunServiceImpl implements KioskRunService{
+
+    private final KioskMapper kioskMapper; // 키오스크 상태 조회용 (ONLINE 여부)
+    private final KioskRunMapper kioskRunMapper; // 실행 세션 insert/update
+
+    // DTO <-> VO 매핑
+    private KioskRunVO dtoToVo(KioskRunStartRequest dto) {
+        KioskRunVO vo = new KioskRunVO();
+        vo.setKioskId(dto.getKioskId());
+        vo.setMemberId(dto.getMemberId());
+        vo.setStatus(RunStatus.RUNNING); // 시작 시 고정
+        vo.setStartedAt(LocalDateTime.now());
+        return vo;
+    }
+
+    // VO <-> DTO 매핑
+    private KioskRunResponse voToDto(KioskRunVO vo) {
+        KioskRunResponse dto = new KioskRunResponse();
+        dto.setRunId(vo.getRunId());
+        dto.setKioskId(vo.getKioskId());
+        dto.setMemberId(vo.getMemberId());
+        dto.setStatus(vo.getStatus());
+        dto.setStartedAt(vo.getStartedAt());
+        dto.setEndedAt(vo.getEndedAt());
+        return dto;
+    }
+
+    @Override
+    @Transactional
+    public KioskRunResponse startRun(KioskRunStartRequest req){
+        Long kioskId = req.getKioskId();
+
+        // 키오스크 행 잠금으로 동시성 제어
+        kioskMapper.lockKioskRow(kioskId);
+
+        // 키오스크 온라인 상태 확인
+        KioskStatus status = kioskMapper.findStatusById(kioskId);
+        if (status == null) {
+            throw new IllegalArgumentException("존재하지 않는 키오스크입니다.");
+        }
+        if (status != KioskStatus.ONLINE) {
+            throw new IllegalStateException("키오스크가 ONLINE 상태가 아닙니다.");
+        }
+
+        // 중복 실행 방지 : 같은 키오스크에 RUNNING이 이미 있으면 거절
+        int runningCount = kioskRunMapper.getRunningCountByKioskId(kioskId);
+        if (runningCount > 0) {
+            throw new IllegalStateException("이미 실행중인 세션이 있습니다.");
+        }
+
+        // Running insert
+        KioskRunVO vo = dtoToVo(req);
+        int inserted = kioskRunMapper.insertRun(vo);
+        if (inserted != 1) {
+            throw new IllegalStateException("실행 시작(insertRun) 실패.");
+        }
+
+        // insert 시 run_id가 세팅되어 있음
+        KioskRunVO saved = kioskRunMapper.readRunAsVO(vo.getRunId());
+        return voToDto(saved);
+    }
+
+    @Override
+    @Transactional
+    public KioskRunResponse endRun(KioskRunEndRequest req){
+        Long runId = req.getRunId();
+
+        // 1) 해당 세션 행 잠금 (동시 종료/취소 경쟁 방지)
+        KioskRunVO cur = kioskRunMapper.lockRunRow(runId);
+        if (cur == null) {
+            throw new IllegalArgumentException("세션이 존재하지 않습니다.");
+        }
+
+        // 2) RUNNING 상태만 종료 가능 (멱등 처리: 이미 COMPLETED/CANCELLED면 그대로 반환)
+        if (cur.getStatus() != RunStatus.RUNNING) {
+            // 이미 종료/취소된 상태면 최신값 조회해서 반환
+            KioskRunVO saved = kioskRunMapper.readRunAsVO(runId);
+            return voToDto(saved);
+        }
+
+        // 3) 상태 전이: RUNNING -> COMPLETED
+        int updated = kioskRunMapper.completeRun(runId, LocalDateTime.now());
+        if (updated != 1) {
+            throw new IllegalStateException("실행 종료(update) 실패");
+        }
+
+        // 4) 최신값 재조회 후 반환
+        KioskRunVO saved = kioskRunMapper.readRunAsVO(runId);
+        return voToDto(saved);
+    }
+
+    @Override
+    @Transactional
+    public KioskRunResponse cancelRun(KioskRunEndRequest req){
+        Long runId = req.getRunId();
+
+        // 1) 해당 세션 행 잠금
+        KioskRunVO cur = kioskRunMapper.lockRunRow(runId);
+        if (cur == null) {
+            throw new IllegalArgumentException("세션이 존재하지 않습니다.");
+        }
+
+        // 2) RUNNING 상태만 취소 (멱등 처리)
+        if (cur.getStatus() != RunStatus.RUNNING) {
+            KioskRunVO saved = kioskRunMapper.readRunAsVO(runId);
+            return voToDto(saved);
+        }
+
+        // 3) 상태 전이: RUNNING -> CANCELLED
+        int updated = kioskRunMapper.cancelRun(runId, LocalDateTime.now());
+        if (updated != 1) {
+            throw new IllegalStateException("실행 취소(update) 실패");
+        }
+
+        // 4) 최신값 재조회 후 반환
+        KioskRunVO saved = kioskRunMapper.readRunAsVO(runId);
+        return voToDto(saved);
+    }
+}

--- a/backend/petcoin/src/main/java/com/petcoin/service/MemberServiceImpl.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/MemberServiceImpl.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberMapper memberMapper;
-    private final PointService pointService;
+//    private final PointService pointService;
     private final PasswordEncoder passwordEncoder;
     private final PointHisService pointHisService;
 

--- a/backend/petcoin/src/main/resources/mapper/KioskMapper.xml
+++ b/backend/petcoin/src/main/resources/mapper/KioskMapper.xml
@@ -24,6 +24,7 @@
  * @history
  *   - 250828 | yukyeong | 최초 생성 (resultMap, 공통 WHERE, read, getListWithPaging, getTotalCount, insert, update, softDelete, transitionStatus 정의)
  *   - 250828 | yukyeong | insert/update에서 status 컬럼 제거 (DB 기본값/전용 전이 쿼리로 일원화)
+ *   - 250829 | yukyeong | findStatusById 추가 (키오스크 ONLINE 여부 확인용), lockKioskRow 추가 (행 잠금: startRun 시 동시 실행 방지용)
  *
 -->
 
@@ -124,5 +125,22 @@
           AND status = #{from}
           AND is_deleted = 0
     </update>
+
+    <!-- 3-2) 키오스크 온라인 여부 조회 -->
+    <select id="findStatusById" resultType="com.petcoin.constant.KioskStatus">
+        SELECT status
+        FROM kiosk
+        WHERE kiosk_id = #{kioskId}
+          AND is_deleted = 0
+    </select>
+
+    <!-- 3-3) 행 잠금: 시작 동시성 제어용 -->
+    <select id="lockKioskRow">
+        SELECT kiosk_id, status
+        FROM kiosk
+        WHERE kiosk_id = #{kioskId}
+            FOR UPDATE
+    </select>
+
 
 </mapper>

--- a/backend/petcoin/src/main/resources/mapper/KioskRunMapper.xml
+++ b/backend/petcoin/src/main/resources/mapper/KioskRunMapper.xml
@@ -23,6 +23,7 @@
  *   - 250827 | yukyeong | Mapper XML 최초 생성 (insertRun, completeRun, cancelRun, readRun, getRunListWithPaging, getTotalRunCount, getRunningCountByKioskId 정의)
  *   - 250827 | yukyeong | readRun 쿼리에서 member 테이블 LEFT JOIN 추가, phone 컬럼 매핑
  *   - 250827 | yukyeong | 공통 WHERE 조건(kioskRunWhere) SQL 분리하여 목록/카운트 재사용
+ *   - 250829 | yukyeong | lockRunRow 추가 (행 잠금: endRun/cancelRun 시 동시성 제어), readRunAsVO 추가 (실행 로직용 VO 재조회: DB DEFAULT/트리거 값 반영)
 -->
 
 
@@ -78,6 +79,21 @@
         FROM kiosk_run
         WHERE kiosk_id = #{kioskId}
           AND status   = 'RUNNING'
+    </select>
+
+    <!-- 1-5) 실행 세션 행 잠금 (종료/취소 시 동시성 제어) -->
+    <select id="lockRunRow">
+        SELECT run_id, status
+        FROM kiosk_run
+        WHERE run_id = #{runId}
+            FOR UPDATE
+    </select>
+
+    <!-- 1-6) 실행 세션 단건 조회 (실행 로직용: VO 반환, DB DEFAULT/트리거 반영값 확인용) -->
+    <select id="readRunAsVO" resultMap="kioskRunMap">
+        SELECT run_id, kiosk_id, member_id, status, started_at, ended_at
+        FROM kiosk_run
+        WHERE run_id = #{runId}
     </select>
 
     <!-- 2-1) 실행 세션 단건 조회 -->

--- a/backend/petcoin/src/test/java/com/petcoin/mapper/KioskMapperTest.java
+++ b/backend/petcoin/src/test/java/com/petcoin/mapper/KioskMapperTest.java
@@ -32,6 +32,9 @@ import static org.junit.jupiter.api.Assertions.*;
  *   - 250828 | yukyeong | transitionStatus_fail2 작성
  *                        - 소프트삭제된 키오스크에 대해 전이 시도
  *                        - updated=0, read 결과 null 확인
+ *   - 250829 | yukyeong | findStatusByIdTest 작성
+ *                        - 사전 등록된 kioskId로 현재 상태 조회
+ *                        - enum 매핑 정상 확인 및 ONLINE 여부 검증
  */
 
 @SpringBootTest
@@ -40,6 +43,23 @@ class KioskMapperTest {
 
     @Autowired
     private KioskMapper kioskMapper;
+
+    @Test
+    @DisplayName("키오스크 상태 조회 테스트 - ONLINE 여부 확인")
+    public void findStatusByIdTest() {
+        // Given
+        Long kioskId = 1L; // 테스트용 PK (사전에 DB에 데이터 있어야 함)
+
+        // When
+        KioskStatus status = kioskMapper.findStatusById(kioskId);
+
+        // Then
+        assertNotNull(status, "조회 결과는 null이면 안 됨");
+        log.info("kioskId={} 의 상태 = {}", kioskId, status);
+
+        // ONLINE 여부 확인
+        assertEquals(KioskStatus.ONLINE, status);
+    }
 
     @Test
     @Transactional

--- a/backend/petcoin/src/test/java/com/petcoin/service/KioskRunServiceTest.java
+++ b/backend/petcoin/src/test/java/com/petcoin/service/KioskRunServiceTest.java
@@ -1,0 +1,77 @@
+package com.petcoin.service;
+
+import com.petcoin.constant.RunStatus;
+import com.petcoin.dto.KioskRunEndRequest;
+import com.petcoin.dto.KioskRunResponse;
+import com.petcoin.dto.KioskRunStartRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * 키오스크 실행 세션 Service 테스트
+ * - 실제 DB와 연동하여 실행 시작 → 종료까지의 전체 플로우를 검증
+ * - @SpringBootTest + @Transactional 환경에서 실행되며, 테스트 종료 후 롤백 처리됨
+ *
+ * 주요 시나리오:
+ *  - 실행 시작 요청(KioskRunStartRequest) → RUNNING 상태 세션 생성
+ *  - 실행 종료 요청(KioskRunEndRequest) → 해당 세션을 COMPLETED 상태로 전이
+ *  - 각 단계에서 runId, 상태 값이 예상대로 반영되는지 단언(assert)
+ *
+ * 로그 출력:
+ *  - 요청/응답 객체 주요 필드(runId, kioskId, memberId, status, startedAt/endedAt)를 INFO 레벨로 출력
+ *  - 실패 시 디버깅을 쉽게 하기 위함
+ *
+ * @author  : yukyeong
+ * @fileName: KioskRunServiceTest
+ * @since   : 250829
+ * @history
+ *   - 250829 | yukyeong | 실행 시작 ~ 종료까지의 정상 흐름 테스트(testRun) 작성
+ */
+
+@SpringBootTest
+@Slf4j
+class KioskRunServiceTest {
+
+    @Autowired
+    private KioskRunService kioskRunService;
+
+    @Test
+    @Transactional
+    @DisplayName("실행 시작부터 종료까지 테스트")
+    public void testRun(){
+        // Given : 실행 시작 요청
+        KioskRunStartRequest startReq = new KioskRunStartRequest();
+        startReq.setKioskId(1L); // 실제 DB에 있는 키오스크 ID
+        startReq.setMemberId(1L); // 실제 DB에 있는 회원 ID
+        log.info("StartReq 생성 -> kioskId={}, memberId={}", startReq.getKioskId(), startReq.getMemberId());
+
+        // When : 실행 시작
+        KioskRunResponse started = kioskRunService.startRun(startReq);
+        log.info("실행 시작 결과 -> runId={}, kioskId={}, memberId={}, status={}, startedAt={}",
+                started.getRunId(), started.getKioskId(), started.getMemberId(),
+                started.getStatus(), started.getStartedAt());
+
+        // Then : Running 상태 확인
+        assertNotNull(started.getRunId());
+        assertEquals(RunStatus.RUNNING, started.getStatus());
+
+        // When : 실행 종료
+        KioskRunEndRequest endReq = new KioskRunEndRequest();
+        endReq.setRunId(started.getRunId());
+        log.info("EndReq 생성 -> runId={}", endReq.getRunId());
+
+        KioskRunResponse ended = kioskRunService.endRun(endReq);
+        log.info("실행 종료 결과 -> runId={}, status={}, endedAt={}",
+                ended.getRunId(), ended.getStatus(), ended.getEndedAt());
+
+        // Then : COMPLETED 상태 확인
+        assertEquals(RunStatus.COMPLETED, ended.getStatus());
+    }
+
+}


### PR DESCRIPTION
1. [KioskMapper] findStatusById 추가 (키오스크 ONLINE 여부 확인용)

2. [KioskMapper.xml]
findStatusById 추가 (키오스크 ONLINE 여부 확인용)

3. [KioskMapperTest]
findStatusByIdTest 작성
- 사전 등록된 kioskId로 현재 상태 조회
- enum 매핑 정상 확인 및 ONLINE 여부 검증

4. [KioskRunMapper]
lockRunRow 추가 (행 잠금: endRun/cancelRun 시 동시성 제어)
readRunAsVO 추가 (실행 로직용 VO 반환, DB DEFAULT/트리거 값 반영 확인용)

5. [KioskRunMapper.xml] 
lockRunRow 추가 (행 잠금: endRun/cancelRun 시 동시성 제어)
readRunAsVO 추가 (실행 로직용 VO 반환, DB DEFAULT/트리거 값 반영 확인용)

6. 조회를 위해 DB에 인덱스 추가
CREATE INDEX idx_kiosk_run_kiosk_id ON kiosk_run(kiosk_id);
- RUNNING 여부 체크/범위잠금 정확도 ↑
CREATE INDEX idx_kiosk_run_kiosk_status ON kiosk_run (kiosk_id, status);
- 목록 조회에서 최근순 정렬도 자주 쓰면 같이(선택)
CREATE INDEX idx_kiosk_run_kiosk_status_started ON kiosk_run (kiosk_id, status, started_at DESC);

7. [KioskRunService]
- startRun : 키오스크가 ONLINE 상태일 때 실행 세션 생성 (RUNNING 시작)
- endRun   : RUNNING → COMPLETED 전이만 허용
- cancelRun: RUNNING → CANCELLED 전이만 허용

8. [KioskRunServiceImpl]
- KioskRunService 인터페이스 구현
- 실행 시작/종료/취소 비즈니스 로직 처리 및 동시성 제어

9. [KioskRunServiceTest]
실행 시작 ~ 종료까지의 정상 흐름 테스트(testRun) 작성
