### PR TITLE
[20250830] 키오스크 세션 컨트롤러 완료

### DIFF
--- a/backend/petcoin/src/main/java/com/petcoin/controller/KioskRunApiController.java
+++ b/backend/petcoin/src/main/java/com/petcoin/controller/KioskRunApiController.java
@@ -1,10 +1,129 @@
-//package com.petcoin.controller;
-//
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//@RestController
-//@RequestMapping("/api/kiosk-runs")
-//public class KioskRunApiController {
-//
-//}
+package com.petcoin.controller;
+
+import com.petcoin.dto.KioskRunEndRequest;
+import com.petcoin.dto.KioskRunResponse;
+import com.petcoin.dto.KioskRunStartRequest;
+import com.petcoin.service.KioskRunService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+/*
+ * 키오스크 실행 세션 API 컨트롤러
+ * - 실행 시작, 종료, 취소를 처리하는 REST API
+ * - 서비스 계층(KioskRunService) 호출 후 결과를 HTTP 응답으로 변환
+ * - 예외 상황은 상태 코드(400, 409, 500)로 매핑하여 클라이언트에 반환
+ *
+ * @author  : yukyeong
+ * @fileName: KioskRunApiController
+ * @since   : 250830
+ * @history
+ *   - 250830 | yukyeong | 최초 생성
+ *                        - 실행 시작 API (POST /api/kiosk-runs) 구현
+ *                        - 실행 종료 API (POST /api/kiosk-runs/{runId}/end) 구현
+ *                        - 실행 취소 API (POST /api/kiosk-runs/{runId}/cancel) 구현
+ *                        - 예외 처리 추가 (IllegalArgumentException → 400, IllegalStateException → 409, 기타 → 500)
+ */
+
+@RestController
+@RequestMapping("/api/kiosk-runs")
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+public class KioskRunApiController {
+
+    private final KioskRunService kioskRunService;
+
+    /**
+     * 실행 시작
+     * - body: { "kioskId": 1, "memberId": 1 }
+     * - 201 Created + Location: /api/kiosk-runs/{runId}
+     */
+    @PostMapping
+    public ResponseEntity<?> start(@Valid @RequestBody KioskRunStartRequest request) {
+        try {
+            // 1) 실행 시작 처리
+            KioskRunResponse res = kioskRunService.startRun(request);
+            // 2) 생성된 리소스의 URI (/api/kiosk-runs/{runId}) 생성
+            URI location = ServletUriComponentsBuilder
+                    .fromCurrentRequest() // 현재 요청 URL (/api/kiosk-runs)
+                    .path("/{id}") // 뒤에 /{id} 붙이기
+                    .buildAndExpand(res.getRunId()) // 실제 runId 값 대입
+                    .toUri(); // URI 객체로 변환
+            // 3) 201 Created + Location 헤더 + body 응답
+            return ResponseEntity.created(location).body(res);
+
+        } catch (IllegalArgumentException e) {
+            // 잘못된 입력값/존재하지 않는 리소스
+            return ResponseEntity.badRequest().body(e.getMessage()); // 400 Bad Request
+        } catch (IllegalStateException e) {
+            // 비즈니스 충돌 (이미 실행중, ONLINE 아님 등)
+            return ResponseEntity.status(409).body(e.getMessage());  // 409 Conflict
+        } catch (Exception e) {
+            // 그 외 알 수 없는 오류
+            log.error("실행 시작 중 서버 오류", e);
+            return ResponseEntity.status(500).body("서버 오류가 발생했습니다."); // 500 Internal Server Error
+        }
+    }
+
+    /**
+     * 실행 종료 (멱등)
+     * - path: /api/kiosk-runs/{runId}/end
+     * - body: {}
+     * - 200 OK
+     */
+    @PostMapping("/{runId}/end")
+    public ResponseEntity<?> end(@PathVariable Long runId) {
+        try {
+            // 1) DTO 생성 (PathVariable → DTO 세팅)
+            KioskRunEndRequest req = new KioskRunEndRequest();
+            req.setRunId(runId);
+            // 2) 실행 종료 처리
+            KioskRunResponse res = kioskRunService.endRun(req);
+            // 3) 200 OK + body 응답
+            return ResponseEntity.ok(res);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage()); // 400 Bad Request (세션 없음 등)
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(409).body(e.getMessage()); // 409 Conflict
+        } catch (Exception e) {
+            log.error("실행 종료 중 서버 오류", e);
+            return ResponseEntity.status(500).body("서버 오류가 발생했습니다."); // 500 Internal Server Error
+        }
+    }
+
+    /**
+     * 실행 취소 (멱등)
+     * - path: /api/kiosk-runs/{runId}/cancel
+     * - body: {}
+     * - 200 OK
+     */
+    @PostMapping("/{runId}/cancel")
+    public ResponseEntity<?> cancel(@PathVariable Long runId) {
+        try {
+            // 1) DTO 생성
+            KioskRunEndRequest req = new KioskRunEndRequest();
+            req.setRunId(runId);
+            // 2) 실행 취소 처리
+            KioskRunResponse res = kioskRunService.cancelRun(req);
+            // 3) 200 OK + body 응답
+            return ResponseEntity.ok(res);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage()); // 400 Bad Request (세션 없음 등)
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(409).body(e.getMessage()); // 409 Conflict
+        } catch (Exception e) {
+            log.error("실행 취소 중 서버 오류", e);
+            return ResponseEntity.status(500).body("서버 오류가 발생했습니다."); // 500 Internal Server Error
+        }
+    }
+
+}

--- a/backend/petcoin/src/main/java/com/petcoin/dto/KioskRunStartRequest.java
+++ b/backend/petcoin/src/main/java/com/petcoin/dto/KioskRunStartRequest.java
@@ -25,7 +25,7 @@ import lombok.*;
 @Builder
 public class KioskRunStartRequest {
 
-    @NotNull
+    @NotNull(message = "kioskId는 필수입니다.")
     private Long kioskId;
 
     // 비회원 허용

--- a/backend/petcoin/src/test/java/com/petcoin/controller/KioskRunApiControllerTest.java
+++ b/backend/petcoin/src/test/java/com/petcoin/controller/KioskRunApiControllerTest.java
@@ -1,0 +1,140 @@
+package com.petcoin.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petcoin.dto.KioskRunStartRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/*
+ * KioskRunApiController 통합 테스트
+ * - MockMvc 기반으로 API 엔드포인트 동작 검증
+ * - 실행 세션의 시작/종료/취소 API가 정상 동작하는지 확인
+ *
+ * 주요 검증 시나리오:
+ *  - start_success_201   : ONLINE 키오스크 + 유효한 회원 → 201 Created
+ *  - end_success_200     : RUNNING 세션 정상 종료 → 200 OK + status=COMPLETED
+ *  - cancel_success_200  : RUNNING 세션 정상 취소 → 200 OK + status=CANCELLED
+ *
+ * @author  : yukyeong
+ * @fileName: KioskRunApiControllerTest.java
+ * @since   : 250830
+ * @history
+ *   - 250830 | yukyeong | 최초 생성
+ *                       - 실행 세션 시작(start_success_201) 성공 케이스 추가
+ *                       - 실행 세션 종료(end_success_200) 성공 케이스 추가
+ *                       - 실행 세션 취소(cancel_success_200) 성공 케이스 추가
+ */
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class KioskRunApiControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    // DTO → JSON 문자열 직렬화 유틸
+    private String toJson(Object dto) throws Exception {
+        return objectMapper.writeValueAsString(dto);
+    }
+
+    // 응답 바디(JSON)에서 runId만 뽑아오는 유틸
+    private long extractRunId(String body) throws Exception {
+        JsonNode node = objectMapper.readTree(body);
+        return node.path("runId").asLong();
+    }
+
+    @Test
+    @WithMockUser(username = "testUser", roles = {"USER"}) // 필요시 ADMIN 등 맞춰 변경
+    @DisplayName("성공: kioskId=1(ONLINE) + memberId=1 → 201 Created + Location")
+    public void start_success_201() throws Exception {
+        // Given: 요청 DTO 구성
+        KioskRunStartRequest req = new KioskRunStartRequest();
+        req.setKioskId(1L); // 현재 DB: kiosk_id=1은 ONLINE
+        req.setMemberId(1L); // 현재 DB: member_id=1 존재
+
+        // when & then: 실행 시작 호출 후 응답 검증
+        mockMvc.perform(post("/api/kiosk-runs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(req)))
+                .andExpect(status().isCreated()) // 201 Created 기대
+                // Location 헤더는 정확한 runId를 가정하지 않고 prefix만 확인
+                .andExpect(header().string("Location", containsString("/api/kiosk-runs/")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON)) // 응답 Content-Type이 application/json인지 확인
+                // 바디 필드 검증
+                .andExpect(jsonPath("$.runId", notNullValue()))
+                .andExpect(jsonPath("$.kioskId").value(1L))
+                .andExpect(jsonPath("$.memberId").value(1L));
+    }
+
+    @Test
+    @WithMockUser(username = "testUser", roles = {"USER"})
+    @DisplayName("성공: RUNNING 세션 종료 → 200 OK + status=COMPLETED")
+    public void end_success_200() throws Exception {
+        // 1) Given : RUNNING 시작
+        KioskRunStartRequest req = new KioskRunStartRequest();
+        req.setKioskId(1L); // ONLINE
+        req.setMemberId(1L); // 존재하는 회원
+
+        String startBody = mockMvc.perform(post("/api/kiosk-runs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(req)))
+                .andExpect(status().isCreated()) // 실행 시작 성공 → 201
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        long runId = extractRunId(startBody); // 이후 종료/취소 호출에 사용할 runId 추출
+
+        // 2) When : 종료 API 호출 & Then : 200 OK + COMPLETED 상태
+        mockMvc.perform(post("/api/kiosk-runs/{runId}/end", runId))
+                .andExpect(status().isOk()) // HTTP 200 OK
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.runId").value(runId))
+                .andExpect(jsonPath("$.status").value("COMPLETED")); // 서비스가 COMPLETED로 세팅한다고 가정
+    }
+
+
+    @Test
+    @WithMockUser(username = "testUser", roles = {"USER"})
+    @DisplayName("성공: RUNNING 세션 취소 → 200 OK + status=CANCELLED")
+    public void cancel_success_200() throws Exception {
+        // Given: RUNNING 세션 시작
+        KioskRunStartRequest req = new KioskRunStartRequest();
+        req.setKioskId(1L);
+        req.setMemberId(1L);
+
+        String startBody = mockMvc.perform(post("/api/kiosk-runs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        long runId = extractRunId(startBody);
+
+        // When: 취소 호출 & Then: 200 OK + CANCELLED 상태
+        mockMvc.perform(post("/api/kiosk-runs/{runId}/cancel", runId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.runId").value(runId))
+                .andExpect(jsonPath("$.status").value("CANCELLED")); // 서비스가 CANCELLED로 세팅한다고 가정
+    }
+
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,5 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './kiosk/App';
 
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);


### PR DESCRIPTION
[KioskRunApiController]
실행 시작 API (POST /api/kiosk-runs) 구현
실행 종료 API (POST /api/kiosk-runs/{runId}/end) 구현
실행 취소 API (POST /api/kiosk-runs/{runId}/cancel) 구현
예외 처리 추가 (IllegalArgumentException → 400, IllegalStateException → 409, 기타 → 500)


[KioskRunApiControllerTest]
실행 세션 시작(start_success_201) 성공 케이스 추가
실행 세션 종료(end_success_200) 성공 케이스 추가
실행 세션 취소(cancel_success_200) 성공 케이스 추가