### PR TITLE
[20250901] 리액트 api 폴더 작업중

### DIFF
--- a/backend/petcoin/src/main/java/com/petcoin/config/WebConfig.java
+++ b/backend/petcoin/src/main/java/com/petcoin/config/WebConfig.java
@@ -1,0 +1,47 @@
+package com.petcoin.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/*
+ * WebConfig.java
+ * - Spring Boot 전역 CORS 설정 클래스
+ * - 프론트엔드(React)와 백엔드(Spring Boot) 간 통신 시
+ *   서로 다른 포트/도메인에서 발생하는 CORS(Cross-Origin Resource Sharing) 문제를 해결
+ *
+ * 주요 기능:
+ *   - "/api/**" 경로로 들어오는 요청에 대해 CORS 허용
+ *   - 허용 Origin:
+ *       • http://localhost:3000        → 로컬 개발 환경(PC 브라우저)
+ *       • http://192.168.10.72:3000    → 동일 네트워크의 아이패드(테스트용)
+ *   - 허용 Methods: GET, POST, PUT, DELETE, OPTIONS
+ *   - 허용 Headers: 모든 요청 헤더("*")
+ *   - allowCredentials(true): 인증 정보(쿠키, 세션 등) 포함한 요청 허용
+ *
+ * 주의사항:
+ *   - allowCredentials(true) 사용 시 allowedOrigins("*") 와일드카드 불가
+ *   - 운영 배포 시 실제 프론트엔드 도메인(예: https://petcoin.com)으로 수정 필요
+ *
+ * @fileName: WebConfig.java
+ * @author  : yukyeong
+ * @since   : 250902
+ * @history
+ *   - 250902 | yukyeong | CORS 기본 설정 추가 - 로컬(3000) 및 아이패드 테스트 IP 허용, allowCredentials 활성화
+ */
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "http://192.168.10.72:3000" // ← 아이패드가 보는 프론트 주소
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*") // 모든 요청 헤더 허용
+                .allowCredentials(true); // 쿠키·세션 등 인증 정보 허용
+    }
+}

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,8 @@
+# 스프링부트 API (회원/JWT/포인트/세션 등)
+REACT_APP_API_URL=http://localhost:8080
+
+# 아이패드 API (키오스크 화면)
+# REACT_APP_API_URL=http://192.168.10.72:8080
+
+# 라즈베리파이 API (컨베이어/AI 요청/결과)
+# REACT_APP_PI_API_URL=http://192.168.10.245:5000

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.11.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2",
@@ -5012,6 +5013,33 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -13894,6 +13922,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,17 +1,38 @@
-import React, { useState } from 'react';
-import UserApp from './user/UserApp';
-import AdminApp from './admin/AdminApp';
-import KioskApp from './kiosk/KioskApp';
+/*
+ * App.js
+ * - 프로젝트 최상위 라우팅 설정
+ * - React Router v6 기준으로 작성
+ *
+ * 주요 기능:
+ *   - "/" → 사용자용 메인 홈페이지(UserApp)
+ *   - "/admin/*" → 관리자 전용(AdminApp)
+ *   - "/kiosk/*" → 키오스크 전용(KioskApp, iPad 접속용)
+ *
+ * @fileName : App.js
+ * @author : yukyeong
+ * @since : 250901
+ * @history
+ *   - 250901 | yukyeong | 최초 생성 및 라우팅 구조 설정 - UserApp, AdminApp, KioskApp 경로 분리
+ *   - 250901 | yukyeong | 관리자 경로에 path="/admin/*" 와일드카드 추가 - 하위 라우트 처리 가능하도록 수정
+ *   - 250901 | yukyeong | 키오스크 전용 경로(/kiosk/*) 추가 - iPad 접속 시 별도 화면 렌더링 지원
+ */
+
+import React from "react";
+import { Routes, Route, Navigate } from "react-router-dom";
+
+// 영역별 App (각 하위 라우트를 내부에서 관리)
+import UserApp from "./user/UserApp";
+import AdminApp from "./admin/AdminApp";
+import KioskApp from "./kiosk/KioskApp";
 
 function App() {
-  const [mode, setMode] = useState('admin'); // 'user' | 'admin' | 'kiosk'
 
   return (
-    <div>
-      {mode === 'user' && <UserApp />}
-      {mode === 'admin' && <AdminApp />}
-      {mode === 'kiosk' && <KioskApp />}
-    </div>
+    <Routes>
+      <Route path="/" element={<UserApp />} /> {/* "/" → 사용자용 메인 홈페이지 */}
+      <Route path="/admin/*" element={<AdminApp />} /> {/* "/admin/*" → 관리자 페이지 */}
+      <Route path="/kiosk/*" element={<KioskApp />} /> {/* "/kiosk/*" → 키오스크 전용 영역 */}
+    </Routes>
   );
 }
 

--- a/frontend/src/admin/AdminApp.js
+++ b/frontend/src/admin/AdminApp.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import AdminDashboard from './admin/components/AdminDashboard'; // 올바른 경로
-import './App.css';
+import AdminDashboard from './components/AdminDashboard'; // 올바른 경로
+import '../App.css';
 
 function App() {
     return (

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -1,0 +1,43 @@
+/*
+ * 관리자(Admin) 관련 API 모듈
+ * - axios 인스턴스(api)를 사용해 Spring Boot 서버와 통신
+ * - 회원 관리 및 포인트 환급 요청 관련 엔드포인트 호출 함수들을 제공
+ *
+ * 주요 기능:
+ *   - getAllMembers(criteria) : 전체 회원 목록 조회 (페이징/검색 포함)
+ *   - getMemberDetail(memberId) : 회원 단건 상세 조회
+ *   - getPointRequests(criteria) : 포인트 환급 요청 목록 조회 (페이징/검색 포함)
+ *   - getPointRequestById(requestId) : 포인트 환급 단건 상세 조회
+ *   - processPointRequest(id, payload) : 포인트 환급 요청 처리 (승인/거절 등 상태 변경)
+ *
+ * 요청 경로는 AdminApiController와 1:1 매핑됨.
+ *
+ * @author  : yukyeong
+ * @fileName: admin.js
+ * @since   : 250901
+ * @history
+ *   - 250901 | yukyeong | 최초 작성 (회원/포인트 환급 관련 API 함수 추가)
+ */
+
+
+import api from './axios';
+
+// 전체 회원 목록 조회 (Criteria를 쿼리로 전달)
+export const getAllMembers = (params) =>
+    api.get('/api/admin/member/list', { params });
+
+// 회원 단건 조회 (서버가 포인트 내역까지 포함해 주면 그대로 사용)
+export const getMemberDetail = (memberId) =>
+    api.get(`/api/admin/member/${memberId}`);
+
+// 포인트 환급 요청 목록 조회 (Criteria를 쿼리스트링으로 전달)
+export const getPointRequests = (params) =>
+    api.get('/api/admin/point/list', { params });
+
+// 포인트 환급 단건 상세 조회
+export const getPointRequestById = (requestId) =>
+    api.get(`/api/admin/point/${requestId}`);
+
+// 포인트 환급 요청 처리 (승인/거절 등 상태 변경)
+export const processPointRequest = (requestId, payload) =>
+    api.put(`/api/admin/point/process/${requestId}`, payload);

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,0 +1,53 @@
+/*
+ * 인증(Auth) 관련 API 모듈
+ * - axios 인스턴스(api)를 사용해 Spring Boot 서버와 통신
+ * - AuthController (/api/auth/**), MemberController (/api/member/**)와 1:1 매핑
+ * - 주요 기능:
+ *   - login(phone, allowAutoRegister) : 로그인(+자동가입) → JWT 발급
+ *   - checkPhone(phone) : 연락처 존재 여부 확인
+ *   - register(phone) : 회원가입(+JWT 즉시 발급)
+ *   - logout() : 클라이언트 토큰 삭제
+ *
+ * DTO 매핑:
+ *   - PhoneRequest : { phone }
+ *   - ExistsResponse : { exists: boolean }
+ *   - TokenResponse : { token: 'Bearer', accessToken, expiresIn? }
+ *
+ * @fileName: auth.js
+ * @author  : yukyeong
+ * @since   : 250902
+ * @history
+ *   - 250902 | yukyeong | 최초 작성 (로그인/회원가입/존재확인/로그아웃 API 함수 추가)
+ */
+
+import api from './axios';
+
+// PhoneRequest DTO 정규화: 숫자만 남김 (010-1111-1111 -> 01011111111)
+export const normalizePhone = (raw) => (raw ?? '').replace(/[^0-9]/g, '');
+
+// 로그인(+자동가입)
+export const login = (phone, allowAutoRegister = true) => {
+    const payload = { phone: normalizePhone(phone) };
+    return api.post(`/api/auth/login`, payload, {
+        params: { allowAutoRegister },
+    });
+};
+
+// 연락처 DB 존재 여부 확인
+export const checkPhone = (phone) => {
+    const payload = { phone: normalizePhone(phone) };
+    return api.post('/api/member/check', payload);
+};
+
+// 회원가입 + 즉시 JWT 발급
+export const register = (phone) => {
+    const payload = { phone: normalizePhone(phone) };
+    return api.post('/api/member/register', payload);
+};
+
+
+// 로그아웃 (클라이언트 토큰 삭제)
+export const logout = () => {
+    localStorage.removeItem('accessToken');
+    // navigate('/login')는 컴포넌트에서 실행
+};

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -1,0 +1,35 @@
+/*
+ * axios 인스턴스 설정 파일
+ * - 공통 baseURL, JSON 기본 헤더, 쿠키 설정 포함
+ * - JWT accessToken 자동 첨부 (localStorage → Authorization 헤더)
+ *
+ * @author  : yukyeong
+ * @fileName: axios.js
+ * @since   : 250901
+ * @history
+ *   - 250901 | yukyeong | 파일 최초 생성
+ *                        - baseURL을 환경변수(REACT_APP_API_URL)로 분리
+ *                        - withCredentials 옵션 활성화 (세션 쿠키 허용)
+ *                        - 기본 Content-Type을 application/json으로 설정
+ *                        - 요청 인터셉터에서 JWT 토큰 자동 부착 처리 추가
+ */
+
+
+import axios from 'axios';
+
+// 1) 인스턴스 생성
+const api = axios.create({
+    baseURL: process.env.REACT_APP_API_URL,
+    withCredentials: true,
+    headers: { 'Content-Type': 'application/json' },
+});
+
+// 2) 인터셉터 설정 (요청 직전)
+api.interceptors.request.use((config) => {
+    const token = localStorage.getItem('accessToken'); // JWT 꺼내오기
+    if (token) config.headers.Authorization = `Bearer ${token}`; // 있으면 헤더에 추가
+    return config;
+});
+
+// 3) 내보내기
+export default api;

--- a/frontend/src/api/axiosPi.js
+++ b/frontend/src/api/axiosPi.js
@@ -1,0 +1,34 @@
+/*
+ * 라즈베리파이 전용 axios 인스턴스 설정 파일
+ * - Flask/FastAPI 등 라즈베리파이 서버와 통신할 때 사용
+ * - baseURL은 환경변수(REACT_APP_PI_API_URL)에서 주입
+ *   예: http://192.168.10.245:5000
+ * - Content-Type을 application/json으로 고정
+ *
+ * 사용 예시:
+ *   import pi from './axiosPi';
+ *
+ *   // 라즈베리파이에 예측 결과 전송
+ *   pi.post('/conveyor/result', { result: 'OK' });
+ *
+ *
+ * @author  : yukyeong
+ * @fileName: axiosPi.js
+ * @since   : 250901
+ * @history
+ *   - 250901 | yukyeong | 파일 최초 생성
+ *                       - baseURL을 라즈베리파이 서버 전용으로 분리
+ *                       - JSON Content-Type 기본 헤더 적용
+ */
+
+
+import axios from 'axios';
+
+// 1) 인스턴스 생성
+const pi = axios.create({
+    baseURL: process.env.REACT_APP_PI_API_URL, // 예: http://192.168.10.245:5000
+    headers: { 'Content-Type': 'application/json' },
+});
+
+// 2) 내보내기
+export default pi;

--- a/frontend/src/api/kiosk.js
+++ b/frontend/src/api/kiosk.js
@@ -1,0 +1,38 @@
+/*
+ * 키오스크 실행 관련 API 모듈
+ * - axios 인스턴스(api)를 사용해 Spring Boot 서버와 통신
+ * - 실행 시작 / 종료 / 취소 요청을 각각 함수로 제공
+ *
+ * 주요 역할:
+ *   - startKioskRun(dto) : 실행 시작 요청 (POST /api/kiosk-runs)
+ *   - endKioskRun(runId) : 실행 종료 요청 (POST /api/kiosk-runs/{runId}/end)
+ *   - cancelKioskRun(runId) : 실행 취소 요청 (POST /api/kiosk-runs/{runId}/cancel)
+ *
+ * 요청 형식:
+ *   - Method: POST
+ *   - URL : /api/kiosk-runs, /api/kiosk-runs/{runId}/end, /api/kiosk-runs/{runId}/cancel
+ *   - Body : JSON (시작: { kioskId, memberId }, 종료/취소: body 없음, runId는 path로 전달)
+ *
+ * @author  : yukyeong
+ * @fileName: kiosk.js
+ * @since   : 250901
+ * @history
+ *   - 250901 | yukyeong | 엔드포인트를 KioskRunApiController 설계에 맞게 수정 (/api/kiosk/run/* → /api/kiosk-runs, /{runId}/end, /{runId}/cancel)
+ * 
+ * 
+ */
+
+
+import api from './axios';
+
+// 키오스크 실행 시작
+export const startKioskRun = (dto) =>
+    api.post('/api/kiosk-runs', dto);
+
+// 키오스크 실행 종료
+export const endKioskRun = (runId) =>
+    api.post(`/api/kiosk-runs/${runId}/end`);
+
+// 키오스크 실행 취소
+export const cancelKioskRun = (runId) =>
+    api.post(`/api/kiosk-runs/${runId}/cancel`);

--- a/frontend/src/api/pi.js
+++ b/frontend/src/api/pi.js
@@ -1,0 +1,13 @@
+// import pi from './axiosPi';
+
+// // 컨베이어 시작
+// export const conveyorStart = (payload) =>
+//     pi.post('/api/conveyor/start', payload);
+
+// // 이미지 예측 요청
+// export const predictImage = (payload) =>
+//     pi.post('/api/predict', payload);
+
+// // 예측 결과 전달 (LED/부저 제어)
+// export const conveyorResult = (payload) =>
+//     pi.post('/api/conveyor/result', payload);

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -1,0 +1,13 @@
+// import api from './axios';
+
+// /** 내 회원 정보 조회 */
+// export const getMyInfo = () =>
+//   api.get('/api/member/me');
+
+// /** 특정 회원 조회 */
+// export const getMember = (memberId) =>
+//   api.get(`/api/member/${memberId}`);
+
+// /** 내 포인트 내역 조회 */
+// export const getMyPoints = () =>
+//   api.get('/api/member/me/points');

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,7 +1,31 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './kiosk/App';
+/*
+ * index.js
+ * - React 애플리케이션의 진입점(entry point)
+ * - index.html의 <div id="root"></div>를 ReactDOM이 찾아서 App 컴포넌트를 마운트
+ *
+ * 주요 기능:
+ *   - ReactDOM.createRoot()로 루트 컨테이너 생성
+ *   - BrowserRouter로 <App/>을 감싸 라우팅 기능 활성화
+ *
+ * @fileName: index.js
+ * @author  : yukyeong
+ * @since   : 250901
+ * @history
+ *   - 250901 | yukyeong | App 컴포넌트를 BrowserRouter로 감싸 라우팅 기능 활성화
+ * 
+ */
 
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+const root = ReactDOM.createRoot(document.getElementById("root"));
+
+// React 애플리케이션 렌더링
+// BrowserRouter로 App을 감싸서, App 내부에서 라우팅 기능을 사용할 수 있게 함
+root.render(
+    <BrowserRouter>
+        <App />
+    </BrowserRouter>
+);

--- a/frontend/src/kiosk/KioskApp.js
+++ b/frontend/src/kiosk/KioskApp.js
@@ -1,3 +1,23 @@
+/*
+ * KioskApp.js
+ * - 키오스크 실행 전용 화면 컴포넌트
+ * - 단계별 화면 전환을 useState로 관리
+ *   (Main → PhoneInput → InsertBottle → Processing → Completion)
+ *
+ * 주요 기능:
+ *   - currentStep 상태값에 따라 화면 전환
+ *   - 각 단계 컴포넌트에 onNext/onBack/onComplete/onHome 콜백 전달
+ *   - 헤더 영역에는 로고 고정 표시
+ *
+ * @fileName: KioskApp.js
+ * @author  : yukyeong
+ * @since   : 250901
+ * @history
+ *   - 250901 | yukyeong | 파일명 App.js → KioskApp.js 로 변경
+ *                        - 함수명 App → KioskApp 으로 수정
+ *                        - export default KioskApp 적용
+ */
+
 import React, { useState } from 'react';
 import MainScreen from './components/MainScreen';
 import PhoneInputScreen from './components/PhoneInputScreen';
@@ -8,7 +28,7 @@ import logoImage from './img/logo.png';
 import './App.css';
 import './styles/common.css';
 
-function App() {
+function KioskApp() {
   const [currentStep, setCurrentStep] = useState(1);
   const [phoneNumber, setPhoneNumber] = useState('');
   const [petBottleCount, setPetBottleCount] = useState(3);
@@ -87,4 +107,4 @@ function App() {
   );
 }
 
-export default App;
+export default KioskApp;

--- a/frontend/src/user/UserApp.js
+++ b/frontend/src/user/UserApp.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import UserMyPage from './components/UserMyPage';
-import './App.css';
+import '../App.css';
 
 // 커스텀 훅 정의
 function useCoupon() {


### PR DESCRIPTION
리액트 시작하기 전에 
npm install react-router-dom
npm install axios
설치하기

1. 리액트 구조 변경
src/
├─ index.js // BrowserRouter로 App 감싸기
├─ App.js // 전체 라우팅 스위치
├─ admin/AdminApp.js // 관리자 전용
├─ user/UserApp.js // 사용자 전용
└─ kiosk/KioskApp.js // 키오스크 전용

2. [App.js]
최초 생성 및 라우팅 구조 설정 - UserApp, AdminApp, KioskApp 경로 분리
관리자 경로에 path="/admin/*" 와일드카드 추가 - 하위 라우트 처리 가능하도록 수정
키오스크 전용 경로(/kiosk/*) 추가 - iPad 접속 시 별도 화면 렌더링 지원

3. [index.js] App 컴포넌트를 BrowserRouter로 감싸 라우팅 기능 활성화
- 실행하기 전에 npm install react-router-dom 설치하기

4. [KioskApp.js]
파일명 App.js → KioskApp.js 로 변경
함수명 App → KioskApp 으로 수정
export default KioskApp 적용

5. 스프링부터와 리액트 연결
[WebConfig.java]
CORS 기본 설정 추가 - 로컬(3000) 및 아이패드 테스트 IP 허용, allowCredentials 활성화

6. 리액트에서 src/api 폴더 따로 만들어서 관리
api 폴더 만들기
api/

지금 폴더 구조 분류
1) 인스턴스 파일 (axios 설정)
axios.js → 스프링부트 서버와 통신할 때 기본 인스턴스
axiosPi.js → 라즈베리파이 서버(Flask 등)와 통신할 때 인스턴스
여기서는 공통 설정만 해두고, 직접 API 함수는 안 넣음
2) 도메인 파일 (API 함수 모음)
auth.js → 로그인/회원가입/토큰
user.js → 사용자 전용 (내 정보, 내 포인트)
admin.js → 관리자 전용 (회원 관리, 포인트 수정)
kiosk.js → 키오스크 실행 세션
pi.js → 라즈베리파이 제어 (AI, 모터 등)
여기서는 axios 인스턴스를 import해서 API 요청 함수를 작성

6-1. [axios.js]
- baseURL을 환경변수(REACT_APP_API_URL)로 분리
- withCredentials 옵션 활성화 (세션 쿠키 허용)
- 기본 Content-Type을 application/json으로 설정
- 요청 인터셉터에서 JWT 토큰 자동 부착 처리 추가

6-2. [axiosPi.js]
- baseURL을 라즈베리파이 서버 전용으로 분리
- JSON Content-Type 기본 헤더 적용

6-3. [kiosk.js]
키오스크 실행 관련 API 모듈 (요청 경로는 KioskRunApiController와 1:1 매핑됨)
- startKioskRun(dto) : 실행 시작 요청 (POST /api/kiosk-runs)
- endKioskRun(runId) : 실행 종료 요청 (POST /api/kiosk-runs/{runId}/end)
- cancelKioskRun(runId) : 실행 취소 요청 (POST /api/kiosk-runs/{runId}/cancel)

6-4. [admin.js]
관리자(Admin) 관련 API 모듈 (요청 경로는 AdminApiController와 1:1 매핑됨)
- getAllMembers(criteria) : 전체 회원 목록 조회 (페이징/검색 포함)
- getMemberDetail(memberId) : 회원 단건 상세 조회
- getPointRequests(criteria) : 포인트 환급 요청 목록 조회 (페이징/검색 포함)
- getPointRequestById(requestId) : 포인트 환급 단건 상세 조회
- processPointRequest(id, payload) : 포인트 환급 요청 처리 (승인/거절 등 상태 변경)

6-5. [auth.js]
인증(Auth) 관련 API 모듈
- login(phone, allowAutoRegister) : 로그인(+자동가입) → JWT 발급
- checkPhone(phone) : 연락처 존재 여부 확인
- register(phone) : 회원가입(+JWT 즉시 발급)
- logout() : 클라이언트 토큰 삭제


7. [.env] 환경변수 파일 만들기
리액트 파일에 실행 주소를 넣는것 보다는 환경변수로 관리하는게 깔끔


