### PR TITLE
[20250904] 분석완료 화면, 초기화 오류 해결

### DIFF
--- a/backend/petcoin/src/main/java/com/petcoin/config/SecurityConfig.java
+++ b/backend/petcoin/src/main/java/com/petcoin/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/mypage/pointrefund/*").permitAll()
                         // 관리자 전용
                         .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/prediction/save").permitAll()
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/backend/petcoin/src/main/java/com/petcoin/controller/AuthController.java
+++ b/backend/petcoin/src/main/java/com/petcoin/controller/AuthController.java
@@ -31,7 +31,7 @@ import java.util.Map;
 @RequestMapping(value = "/api/auth")
 @Slf4j
 public class AuthController {
-    
+
     private final JwtTokenProvider jwtTokenProvider; //토큰 발급 유틸
     private final MemberMapper memberMapper; //회원 조회, 저장
     private final PasswordEncoder passwordEncoder; //비밀번호 암호화
@@ -102,7 +102,7 @@ public class AuthController {
         }
         // 2. 회원 조회
         MemberVO member = memberMapper.findByPhone(phone);
-        
+
         // 3. 없으면 에러 발생
         if (member == null) {
             return ResponseEntity.status(404).body("NO_SUCH_MEMBER");
@@ -113,9 +113,9 @@ public class AuthController {
         // 5. 응답 반환
         return ResponseEntity.ok(
                 TokenResponse.builder()
-                .token("Bearer")
-                .accessToken(jwt)
-                .build()
+                        .token("Bearer")
+                        .accessToken(jwt)
+                        .build()
         );
     }
 }

--- a/backend/petcoin/src/main/java/com/petcoin/service/PetCollectionLogServiceImpl.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/PetCollectionLogServiceImpl.java
@@ -23,7 +23,7 @@ public class PetCollectionLogServiceImpl implements PetCollectionLogService {
     private final PetCollectionLogMapper petCollectionLogMapper;
     private final FileService fileService;
 
-    private final String uploadPath = "/path/to/image/upload"; // 실제 이미지 저장 경로 지정
+    private final String uploadPath = "C:\\petcoin"; // 실제 이미지 저장 경로 지정
 
     @Override
     @Transactional

--- a/backend/petcoin/src/main/java/com/petcoin/service/PointHisServiceImpl.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/PointHisServiceImpl.java
@@ -106,6 +106,11 @@ public class PointHisServiceImpl implements PointHisService {
     //포인트 적립 내역 추가
     @Override
     public void plusPoint(Long memberId, int totalPet) {
+        // memberId가 null이면 1로 처리
+        if (memberId == null) {
+            memberId = 1L;
+        }
+
         int pointChange = totalPet * POINT_PER_PET; // 규칙에 따라 계산
 
         //1. 현재 포인트 잔액 조회(null일 경우 정수 0으로 변환)

--- a/frontend/src/api/pi.js
+++ b/frontend/src/api/pi.js
@@ -1,3 +1,14 @@
+/*
+ * @fileName : pi.js
+ * @description : 라즈베리파이와 통신하는 키오스크 전용 API 모듈
+ * @author : yukyeong
+ * @since : 250903
+ * @history
+ *   - 250903 | yukyeong | conveyorStart: 컨베이어 동작 시작 요청 API 추가
+ *   - 250903 | yukyeong | predictImage: AI 이미지 예측 요청 API 추가
+ *   - 250903 | yukyeong | conveyorResult: 예측 결과(정상/불량) 전달 API 추가 (LED/부저 제어용)
+ */
+
 import pi from './axiosPi';
 
 // 컨베이어 시작
@@ -11,3 +22,9 @@ export const predictImage = (payload) =>
 // 예측 결과 전달 (LED/부저 제어)
 export const conveyorResult = (payload) =>
     pi.post('/api/conveyor/result', payload);
+
+// 분석 상태 확인
+export const checkAnalysisComplete = (runId) =>
+    pi.get('/api/analysis/status', {
+        params: { runId },
+    });

--- a/frontend/src/kiosk/KioskApp.js
+++ b/frontend/src/kiosk/KioskApp.js
@@ -40,6 +40,7 @@ function KioskApp() {
   const [petBottleCount, setPetBottleCount] = useState(3);
   const [points, setPoints] = useState(1000);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [runId, setRunId] = useState(null); // runId 상태 추가
 
   const goToStep = (step) => {
     setCurrentStep(step);
@@ -53,9 +54,14 @@ function KioskApp() {
 
   // 홈으로 이동하면 초기화
   const handleGoHome = () => {
+    console.log('🏠 홈 초기화 실행');
+
     setPhoneNumber('');
     setAccessToken(null);
-    setCurrentStep(1);
+    setRunId(null); // runId도 초기화
+    setPetBottleCount(0); // 페트병 수 초기화
+    setPoints(0); // 포인트 초기화
+    setCurrentStep(1); // 메인 화면으로
   };
 
   const renderCurrentStep = () => {
@@ -95,17 +101,26 @@ function KioskApp() {
       case 3:
         return (
           <InsertBottleScreen
-            onNext={() => goToStep(4)}   // 다음 단계로 (예: 포인트 확인 화면)
+            onNext={(runId) => {
+              setRunId(runId);  // runId 저장!
+              goToStep(4);      // 다음 단계로 이동
+            }}   // 다음 단계로 (예: 포인트 확인 화면)
             onBack={() => goToStep(2)}   // 전화번호 입력 화면으로 되돌아감
             accessToken={accessToken} // 필요 시 API 호출용
             memberId={memberId}   // 동적으로 추출
             kioskId={kioskId}     // 기기 고유값
+            setRunId={setRunId} // runId를 상위에 저장하도록 props 전달
           />
         );
       case 4:
         return (
           <ProcessingScreen
-            onComplete={() => goToStep(5)}
+            runId={runId} // runId 전달
+            onComplete={() => {
+              // runId가 null이 아닐 때만 step 5로
+              if (runId) goToStep(5);
+              else console.error('runId 없음! CompletionScreen으로 이동 방지됨');
+            }}
           />
         );
       case 5:
@@ -113,6 +128,7 @@ function KioskApp() {
           <CompletionScreen
             petBottleCount={petBottleCount}
             points={points}
+            runId={runId}
             onHome={handleGoHome} // 초기화 포함
           />
         );

--- a/frontend/src/kiosk/components/CompletionScreen.js
+++ b/frontend/src/kiosk/components/CompletionScreen.js
@@ -1,8 +1,56 @@
-import React from 'react';
-import '../styles/common.css';
+/*
+ * CompletionScreen.js
+ * - 키오스크 페트병 분석 완료 화면 컴포넌트
+ * - 분석이 완료되면 종료 API 호출 후, 결과(성공 개수/포인트/잔여포인트)를 사용자에게 안내
+ *
+ * 주요 기능:
+ *   - runId 기반 종료 처리 API 호출 (endKioskRun)
+ *   - 페트병 개수 및 적립 포인트 UI 표시
+ *   - 홈으로 가기 버튼 클릭 시 초기화 콜백 실행
+ *
+ * 화면 구성:
+ *   - 분석 성공 아이콘 및 안내 타이틀
+ *   - 페트병 성공 수량 뱃지, 하트 아이콘, 포인트 적립 안내
+ *   - 잔여 포인트 표시 및 홈 버튼
+ *
+ * 사용 API:
+ *   - POST /api/kiosk/end (runId 기반 종료 처리)
+ *
+ * @fileName : CompletionScreen.js
+ * @author   : yukyeong
+ * @since    : 250904
+ * @history
+ *   - 250904 | yukyeong | 최초 생성 - 분석 완료 화면 UI 및 포인트/성공 수량 렌더링
+ *   - 250904 | yukyeong | runId 기반 종료 처리 API 연동(endKioskRun) 및 useEffect 적용
+ *   - 250904 | yukyeong | 홈으로 가기 버튼 클릭 시 초기화 함수(onHome) 호출 처리
+ */
 
-const CompletionScreen = ({ petBottleCount, points, onHome }) => {
+import React, { useEffect } from 'react';
+import '../styles/common.css';
+import { endKioskRun } from '../../api/kiosk';
+
+const CompletionScreen = ({ petBottleCount, points, onHome, runId }) => {
   const pointsEarned = petBottleCount * 10;
+
+  useEffect(() => {
+    console.log('[CompletionScreen] 마운트됨. runId:', runId);
+
+    const completeRun = async () => {
+      if (!runId) {
+        console.warn('[CompletionScreen] runId 없음 → 종료 요청 생략');
+        return;
+      }
+
+      try {
+        const response = await endKioskRun(runId);
+        console.log('[CompletionScreen] 종료 API 호출 성공:', response.data);
+      } catch (err) {
+        console.error('[CompletionScreen] 종료 API 호출 실패:', err);
+      }
+    };
+
+    completeRun();
+  }, [runId]); // 마운트 시 한 번만 실행
 
   const handleHomeClick = () => {
     console.log('홈으로 가기 버튼 클릭됨'); // 디버깅용
@@ -14,30 +62,30 @@ const CompletionScreen = ({ petBottleCount, points, onHome }) => {
       <div className="success-icon">
         ✓
       </div>
-      
+
       <h1 className="title">분석 완료!</h1>
-      
+
       <div className="result-card">
         <div className="pet-count-badge">
           페트병 {petBottleCount}개 중 {petBottleCount}개 성공!
         </div>
-        
+
         <div className="heart-icon">
           <span>♡</span>
         </div>
-        
+
         <div className="points-earned">
           +{pointsEarned} 포인트 적립
         </div>
-        
+
         <div className="points-display">
           <span>잔여 포인트:</span>
           <span style={{ fontWeight: 'bold' }}>{points.toLocaleString()}p</span>
         </div>
       </div>
-      
+
       <div className="button-group" style={{ marginTop: '40px' }}>
-        <button 
+        <button
           className="main-button member-button"
           onClick={handleHomeClick}
           type="button"

--- a/frontend/src/kiosk/components/InsertBottleScreen.js
+++ b/frontend/src/kiosk/components/InsertBottleScreen.js
@@ -25,7 +25,8 @@ import '../styles/common.css';
 import { conveyorStart } from '../../api/pi';
 import { startKioskRun } from '../../api/kiosk';
 
-const InsertBottleScreen = ({ onNext, onBack, memberId, kioskId }) => {
+// 상위 컴포넌트(KioskApp)에서 전달할 setRunId를 props로 추가
+const InsertBottleScreen = ({ onNext, onBack, memberId, kioskId, setRunId }) => {
   const [showInstructions, setShowInstructions] = useState(true);
   const [isStarting, setIsStarting] = useState(false);
 
@@ -46,6 +47,8 @@ const InsertBottleScreen = ({ onNext, onBack, memberId, kioskId }) => {
       const runId = runResponse.data.runId;
       console.log("생성된 runId:", runId);
 
+      setRunId(runId); // run_id 추가
+
       // 콘솔에 확인용 로그 추가
       console.log("✔️ 라즈베리파이에 전달할 데이터:");
       console.log("memberId:", memberId);
@@ -62,7 +65,7 @@ const InsertBottleScreen = ({ onNext, onBack, memberId, kioskId }) => {
       // 3초 후 다음 단계로 이동
       setTimeout(() => {
         console.log('다음 화면으로 이동');
-        onNext();
+        onNext(runId);
       }, 3000);
 
     } catch (error) {

--- a/frontend/src/kiosk/styles/common.css
+++ b/frontend/src/kiosk/styles/common.css
@@ -744,6 +744,7 @@ button:focus {
   justify-content: space-between;
   align-items: center;
   font-size: 16px;
+  color: #333;
 }
 
 .points-earned {


### PR DESCRIPTION
1. 어제 키오스크 휴대폰 번호 입력 화면 코드 충돌 발생
[PhoneInputScreen.js]
없는 회원이 번호 입력하면 회원이 아니라고 알려주는 모달창과
핸드폰 번호를 입력하고 인증 성공 시 토큰 저장하는 부분이 충돌남
둘 다  필요한 코드라서 사용함

2. 키오스크 분석중 → 분석완료 화면으로 이동할 때 뭘 기준으로 이동할것인지 결정
지금 구조는 무조건 3초 후 자동 이동하는 구조. 
이게 진짜 “분석 중”인지와 상관 없이 화면이 넘어가버리는 문제 발생
라즈베리파이(Flask)가 분석을 끝냈는지 확인한 뒤 다음화면으로 넘어가는 것이 필요

⇒ 우선 간단하게 플라스크에서 상태 확인하는 방법으로 결정
(**Flask 서버에서 분석 완료 상태를 확인하는 API**를 하나 추가해서, 
React(ProcessingScreen)에서 polling 방식으로 분석 완료 여부를 체크)

[api/pi.js]
conveyorStart: 컨베이어 동작 시작 요청 API 추가
predictImage: AI 이미지 예측 요청 API 추가
conveyorResult: 예측 결과(정상/불량) 전달 API 추가 (LED/부저 제어용)

[api/pi.js]에 checkAnalysisComplete에 추가
[ProcessingScreen.js] 
분석 완료 상태 polling 및 자동 전환 처리
loading-spinner 및 분석 안내 텍스트 UI 구성
polling 중 메모리 누수 방지를 위한 clearInterval 정리 처리

플라스크 서버에 분석 상태 확인 요청을 계속 보내는데, 플라스크에 응답이 없으니까 계속 에러 메세지가 쌓임.
이걸 해결하기 위해 예외 처리 및 제한 로직 추가
[ProcessingScreen.js]
Flask 서버 미응답 시 최대 30회까지 재시도, 이후 자동 취소 처리 추가
분석 완료 응답 수신 시 자동 전환, 실패 시 사용자 alert 후 run 종료

3. CompletionScreen.js 분석완료 화면
[CompletionScreen.js]
분석 완료 화면 UI 및 포인트/성공 수량 렌더링
runId 기반 종료 처리 API 연동(endKioskRun) 및 useEffect 적용
홈으로 가기 버튼 클릭 시 초기화 함수(onHome) 호출 처리

[KioskApp.js]
InsertBottleScreen에 memberId, kioskId 동적 전달 처리 완료 (case 3 수정)



4. CompletionScreen.js 분석완료 화면
[KioskApp.js] 초기화 오류 해결
handleGoHome 실행 시 runId, phoneNumber, token, count, point 상태 초기화 확인용 console 추가
CompletionScreen → onHome 실행 시 정상적으로 MainScreen 복귀 및 초기화되도록 검증 완료

