### PR TITLE
[20250905] 비회원이랑 회원 분기 완료, 키오스크 취소상태 전이 완료

### DIFF
--- a/backend/petcoin/src/main/java/com/petcoin/controller/KioskRunApiController.java
+++ b/backend/petcoin/src/main/java/com/petcoin/controller/KioskRunApiController.java
@@ -31,6 +31,7 @@ import java.net.URI;
  *                        - 실행 취소 API (POST /api/kiosk-runs/{runId}/cancel) 구현
  *                        - 예외 처리 추가 (IllegalArgumentException → 400, IllegalStateException → 409, 기타 → 500)
  *                        - 세션 종료시 회수 페트병 수 받아서 dto에 넣어야 함
+ *   - 250905 | yukyeong | POST /api/kiosk-runs/{runId}/cancel 엔드포인트에서 포인트 부수효과 제거
  */
 
 @RestController

--- a/backend/petcoin/src/main/java/com/petcoin/mapper/KioskRunMapper.java
+++ b/backend/petcoin/src/main/java/com/petcoin/mapper/KioskRunMapper.java
@@ -35,6 +35,7 @@ import java.util.List;
  * @history
  *   - 250827 | yukyeong | Mapper 최초 생성 (insertRun, completeRun, cancelRun, readRun, getRunListWithPaging, getTotalRunCount, getRunningCountByKioskId 메서드 정의)
  *   - 250829 | yukyeong | lockRunRow 추가 (행 잠금: endRun/cancelRun 시 동시성 제어), readRunAsVO 추가 (실행 로직용 VO 반환, DB DEFAULT/트리거 값 반영 확인용)
+ *   - 250905 | yukyeong | cancelRun 시 포인트 관련 로직 제거, ended_at만 업데이트하도록 정리
  */
 
 @Mapper

--- a/backend/petcoin/src/main/java/com/petcoin/service/KioskRunServiceImpl.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/KioskRunServiceImpl.java
@@ -43,6 +43,7 @@ import java.util.List;
  *   - 250904 | sehui | 실행 세션 단건 조회 메서드 추가
  *   - 250904 | sehui | 실행 세션 목록 조회 (페이징 + 조건) 메서드 추가
  *   - 250904 | sehui | 실행 세션 총 개수 조회 메서드 추가
+ *   - 250905 | yukyeong | 취소 로직에서 PointHistory 조회/적립 제거 → 순수 상태 전이(RUNNING→CANCELLED)만 수행
  */
 
 @Service

--- a/backend/petcoin/src/main/resources/mapper/KioskRunMapper.xml
+++ b/backend/petcoin/src/main/resources/mapper/KioskRunMapper.xml
@@ -24,6 +24,7 @@
  *   - 250827 | yukyeong | readRun 쿼리에서 member 테이블 LEFT JOIN 추가, phone 컬럼 매핑
  *   - 250827 | yukyeong | 공통 WHERE 조건(kioskRunWhere) SQL 분리하여 목록/카운트 재사용
  *   - 250829 | yukyeong | lockRunRow 추가 (행 잠금: endRun/cancelRun 시 동시성 제어), readRunAsVO 추가 (실행 로직용 VO 재조회: DB DEFAULT/트리거 값 반영)
+ *   - 250905 | yukyeong | cancelRun 쿼리 단순화: status='CANCELLED', ended_at=현재시간만 업데이트 (포인트/총수량 연산 제거)
 -->
 
 

--- a/frontend/src/kiosk/KioskApp.js
+++ b/frontend/src/kiosk/KioskApp.js
@@ -22,6 +22,11 @@
  *   - 250904 | yukyeong | CompletionScreen에서 runId 기반 종료 처리 및 handleGoHome 초기화 검증
  *   - 250904 | yukyeong | handleGoHome 실행 시 runId, phoneNumber, token, count, point 상태 초기화 확인용 console 추가
  *   - 250904 | yukyeong | CompletionScreen → onHome 실행 시 정상적으로 MainScreen 복귀 및 초기화되도록 검증 완료
+ *   - 250905 | yukyeong | ProcessingScreen → onComplete({ status, totalPet }) 처리: DONE이면 step5로 이동 및 수량 세팅, 그 외(TIMEOUT/ERROR)에는 홈으로 복귀
+ *   - 250905 | yukyeong | points 상태 제거, petBottleCount 초기값 0으로 정리, handleGoHome 초기화 로직 정비
+ *   - 250905 | yukyeong | InsertBottleScreen에 accessToken 전달 및 onBack을 회원/비회원에 따라 (2단계/1단계) 분기
+ *   - 250905 | yukyeong | JWT 디코딩으로 memberId 추출 로직 정리 및 runId 가드 추가
+ *   - 250905 | yukyeong | CompletionScreen에 status="DONE" 전달(취소/에러 시 종료 API 호출 방지와 연계)
  * 
  */
 

--- a/frontend/src/kiosk/components/CompletionScreen.js
+++ b/frontend/src/kiosk/components/CompletionScreen.js
@@ -25,6 +25,9 @@
  *   - 250904 | yukyeong | 홈으로 가기 버튼 클릭 시 초기화 함수(onHome) 호출 처리
  *   - 250905 | yukyeong | endKioskRun 호출 시 totalPet 전달, 응답 기반 회원/비회원 UI 분기
  *   - 250905 | yukyeong | points prop 제거, remainingPoints를 서버 응답으로 표시
+ *   - 250905 | yukyeong | status prop('DONE'|'TIMEOUT'|'ERROR') 도입 → DONE일 때만 endKioskRun 호출
+ *   - 250905 | yukyeong | runId 유효성 가드 및 콘솔 로그 정리, useEffect deps를 [status, runId, petBottleCount]로 조정
+ *   - 250905 | yukyeong | endKioskRun에 { totalPet } 전달, 응답(memberId/pointBalance) 기반으로 회원/비회원 UI 및 잔여 포인트 표시
  */
 
 import React, { useEffect, useState } from 'react';

--- a/frontend/src/kiosk/components/ProcessingScreen.js
+++ b/frontend/src/kiosk/components/ProcessingScreen.js
@@ -26,6 +26,8 @@
  *   - 250905 | yukyeong | runId 가드 추가 및 폴링 시작/진행/완료/타임아웃/에러/언마운트 단계별 콘솔 로그 정리
  *   - 250905 | yukyeong | 성공 시 onComplete({ totalPet }) 전달, 타임아웃/에러 초과 시 onComplete({ totalPet: 0 })로 일관화
  *   - 250905 | yukyeong | 타임아웃/에러 시 cancelKioskRun 호출 로깅 보강
+ *   - 250905 | yukyeong | Flask 응답 done을 엄격 비교(res?.data?.done === true)로 변경, totalPet 안전 파싱 보강
+ *   - 250905 | yukyeong | onComplete에 status('DONE'|'TIMEOUT'|'ERROR') 포함하도록 계약 
  */
 
 import React, { useEffect } from 'react';


### PR DESCRIPTION
1. 키오스크 회원과 비회원 분기 작업
[MainScreen.js]
이미 회원/비회원 버튼 있고 onNext('member'|'nonMember') 호출하니 그대로 OK.

[KioskApp.js] 여기서 모드에 따라 startRun 호출 타이밍만 분기.
1) 비회원(guest) 즉시 세션 시작 보장 (InsertBottleScreen 내부 코드 수정 필요)
지금은 nonMember 선택 시 3단계로만 이동하고, 실제 startRun 호출은 InsertBottleScreen 쪽에 기대고 있음
InsertBottleScreen 진입 시점에 runId가 없으면 자동으로 startRun 호출하도록 안전장치 필요
- startKioskRun 호출 시 accessToken 전달 로직 반영 (회원/비회원 구분)
- runId 미생성/에러 상황에 대한 예외 처리 및 상태코드별 알림 추가
- 시작 중(back 버튼 클릭) 방지 로직 추가

[kiosk.js]
회원/비회원 구분과 totalPet 전달이 필요하다면 지금처럼 수정이 필요
- startKioskRun에 accessToken 옵션 추가 (회원/비회원 구분 처리)
- endKioskRun, cancelKioskRun에 body 전달 가능하도록 수정 (totalPet 지원)

2) [CompletionScreen.js]
지금처럼 백엔드 응답으로 isMember를 판단하는 방식
- 현재 방식(권장): endKioskRun(runId, { totalPet }) 응답의 memberId 존재 여부로 isMember 결정
- 장점: 서버가 단일 진실원(Single Source of Truth) → 조작/비동기 오류에 강함, 이전 단계 상태에 의존 X
- 결과: CompletionScreen이 self-contained (응답만으로 UI 확정)


3) [ProcessingScreen.js]
- runId 가드 추가 및 폴링 시작/진행/완료/타임아웃/에러/언마운트 단계별 콘솔 로그 정리
- 성공 시 onComplete({ totalPet }) 전달, 타임아웃/에러 초과 시 onComplete({ totalPet: 0 })로 일관화
- 타임아웃/에러 시 cancelKioskRun 호출 로깅 보강
- Flask 응답 done을 엄격 비교(res?.data?.done === true)로 변경, totalPet 안전 파싱 보강
- onComplete에 status('DONE'|'TIMEOUT'|'ERROR') 포함하도록 계약 

4) [CompletionScreen.js]
- endKioskRun 호출 시 totalPet 전달, 응답 기반 회원/비회원 UI 분기
- points prop 제거, remainingPoints를 서버 응답으로 표시
- status prop('DONE'|'TIMEOUT'|'ERROR') 도입 → DONE일 때만 endKioskRun 호출
- runId 유효성 가드 및 콘솔 로그 정리, useEffect deps를 [status, runId, petBottleCount]로 조정
- endKioskRun에 { totalPet } 전달, 응답(memberId/pointBalance) 기반으로 회원/비회원 UI 및 잔여 포인트 표시


5) 최종 [KioskApp.js]
- ProcessingScreen → onComplete({ status, totalPet }) 처리: DONE이면 step5로 이동 및 수량 세팅, 그 외(TIMEOUT/ERROR)에는 홈으로 복귀
- points 상태 제거, petBottleCount 초기값 0으로 정리, handleGoHome 초기화 로직 정비
- InsertBottleScreen에 accessToken 전달 및 onBack을 회원/비회원에 따라 (2단계/1단계) 분기
- JWT 디코딩으로 memberId 추출 로직 정리 및 runId 가드 추가
- CompletionScreen에 status="DONE" 전달(취소/에러 시 종료 API 호출 방지와 연계)



2. 키오스크 상태 취소로 상태전이

- 스프링부트에서 취소 부분만 원래 코드로 돌리기 (포인트 추가하기 전)
[KioskRunMapper] cancelRun 시 포인트 관련 로직 제거, ended_at만 업데이트하도록 정리
[KioskRunMapper.xml] cancelRun 쿼리 단순화: status='CANCELLED', ended_at=현재시간만 업데이트 (포인트/총수량 연산 제거)
[KioskRunServiceImpl] 취소 로직에서 PointHistory 조회/적립 제거 → 순수 상태 전이(RUNNING→CANCELLED)만 수행
[KioskRunApiController] POST /api/kiosk-runs/{runId}/cancel 엔드포인트에서 포인트 부수효과 제거

-리액트에서 ‘취소’ 관련 수정사항
[ProcessingScreen]
엄격 비교: Flask 응답 done을 res?.data?.done === true로 체크 → false/undefined면 절대 완료로 처리 안 함.
타임아웃/에러 시 취소 호출:
2초 간격 폴링, 최대 30회(≈60초) 동안 완료 안 되면 cancelKioskRun(runId) 호출.
폴링 중 에러가 누적돼도 최대 횟수 도달 시 cancelKioskRun(runId) 호출.
상위로 결과 계약 전달:
성공이면 onComplete({ status: 'DONE', totalPet })
타임아웃이면 onComplete({ status: 'TIMEOUT', totalPet: 0 })
에러 누적이면 onComplete({ status: 'ERROR', totalPet: 0 })
runId 가드: runId 없으면 폴링 시작 자체를 막음.

[KioskApp]
Processing 결과에 따른 분기 강화:
status === 'DONE'일 때만 Step5(Completion)로 이동하고, 그 외(TIMEOUT/ERROR)는 **알림 후 handleGoHome()**로 초기화.
이렇게 해서 취소/에러 상태에서 완료 화면으로 넘어가는 오동작을 차단.

[CompletionScreen]
status !== 'DONE'이면 종료 API(endKioskRun) 자체를 호출하지 않도록 설계(안전).
실제 구현에선 KioskApp이 완료일 때만 Completion을 띄우니 중복 방지 효과.

참고: InsertBottleScreen은 취소 로직과 직접 관련은 없고,
세션 시작(start) 실패 처리,
시작 중 Back 버튼 무효화,
Pi로 보낼 때 memberId가 falsy면 아예 빼는 형태로 정돈(비회원 호환성).
이는 취소 전이에는 영향 없음.

