### PR TITLE
[20250911] 관리자 페이지- 수거내역 탭 완료, 대시보드 키오스크 부분 완료, 키오스크 탭 미완

### DIFF
--- a/backend/petcoin/src/main/java/com/petcoin/dto/StatusUpdateRequest.java
+++ b/backend/petcoin/src/main/java/com/petcoin/dto/StatusUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.petcoin.dto;
+
+import com.petcoin.constant.KioskStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 키오스크 상태 변경 요청 DTO
+ * 프론트엔드에서 보낸 status 값을 매핑
+ *
+ * 예시 JSON:
+ * {
+ *   "status": "ONLINE" | "MAINT" | "OFFLINE"
+ * }
+ *
+ * @author : yukyeong
+ * @fileName : StatusUpdateRequest
+ * @since  : 250911
+ * @history
+ *  - 250911 | yukyeong | 최초 생성 - 키오스크 상태 변경 요청 DTO 정의
+ */
+
+@Getter @Setter
+public class StatusUpdateRequest {
+
+    @NotNull(message = "상태값은 필수입니다.")
+    private KioskStatus status; // ONLINE | MAINT | OFFLINE
+
+}

--- a/backend/petcoin/src/main/java/com/petcoin/mapper/KioskMapper.java
+++ b/backend/petcoin/src/main/java/com/petcoin/mapper/KioskMapper.java
@@ -36,6 +36,7 @@ import java.util.List;
  *   - 250828 | yukyeong | Mapper 최초 생성 (read, getListWithPaging, getTotalCount, insert, update, softDelete, transitionStatus 정의)
  *   - 250829 | yukyeong | findStatusById 추가 (키오스크 ONLINE 여부 확인용), lockKioskRow 추가 (행 잠금: startRun 시 동시 실행 방지용)
  *   - 250905 | sehui | 대시보드에서 조회할 키오스크 운영 상태별 개수 조회 기능 추가
+ *   - 250911 | yukyeong | 관리자 페이지 전용 updateStatus 메서드 추가 (키오스크 상태 단순 변경: ONLINE/MAINT/OFFLINE)
  */
 
 @Mapper
@@ -50,6 +51,10 @@ public interface KioskMapper {
 
     // 1-3) 키오스크 총 개수 조회
     public int getTotalCount(KioskCriteria cri);
+
+    // 1-4) 관리자 페이지에서 키오스크 상태 변경
+    public int updateStatus(@Param("kioskId") Long kioskId,
+                            @Param("status") KioskStatus status);
 
 
     // 관리자페이지에서 키오스크 등록, 수정, 삭제

--- a/backend/petcoin/src/main/java/com/petcoin/service/KioskService.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/KioskService.java
@@ -1,5 +1,6 @@
 package com.petcoin.service;
 
+import com.petcoin.constant.KioskStatus;
 import com.petcoin.dto.KioskCriteria;
 import com.petcoin.dto.KioskResponse;
 
@@ -14,6 +15,7 @@ import java.util.List;
  * @history
  * - 250905 | sehui | 키오스크 장치 단건/전체 조회 기능 추가
  * - 250905 | sehui | 키오스크 등록, 수정, 삭제 기능 추가
+ * - 250911 | yukyeong | 관리자 전용 키오스크 상태 변경(updateStatus) 기능 추가
  */
 
 public interface KioskService {
@@ -35,4 +37,7 @@ public interface KioskService {
 
     //키오스크 소프트삭제
     public int softDelete(Long kioskId);
+
+    // 관리자 페이지-키오스크탭: 키오스크 상태 단순 변경 (ONLINE/MAINT/OFFLINE)
+    public int updateStatus(Long kioskId, KioskStatus status);
 }

--- a/backend/petcoin/src/main/java/com/petcoin/service/KioskServiceImpl.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/KioskServiceImpl.java
@@ -1,5 +1,6 @@
 package com.petcoin.service;
 
+import com.petcoin.constant.KioskStatus;
 import com.petcoin.domain.KioskVO;
 import com.petcoin.dto.KioskCriteria;
 import com.petcoin.dto.KioskResponse;
@@ -21,6 +22,7 @@ import java.util.NoSuchElementException;
  * @history
  * - 250905 | sehui | 키오스크 장치 단건/전체 조회 기능 추가
  * - 250905 | sehui | 키오스크 등록, 수정, 삭제 기능 추가
+ * - 250911 | yukyeong | updateStatus 메서드 추가 (관리자 전용 상태 변경: ONLINE/MAINT/OFFLINE)
  */
 
 @Service
@@ -143,5 +145,18 @@ public class KioskServiceImpl implements KioskService {
         }
 
         return deleteResult;
+    }
+
+    // 관리자 페이지-키오스크탭: 키오스크 상태 변경 (ONLINE/MAINT/OFFLINE)
+    @Override
+    public int updateStatus(Long kioskId, KioskStatus status) {
+        int result = kioskMapper.updateStatus(kioskId, status);
+
+        if (result != 1) {
+            throw new IllegalStateException("키오스크 상태 변경 실패: kioskId=" + kioskId + ", status=" + status);
+        }
+
+        log.info("키오스크 상태 변경 성공: kioskId={}, status={}", kioskId, status);
+        return result;
     }
 }

--- a/backend/petcoin/src/main/resources/mapper/KioskMapper.xml
+++ b/backend/petcoin/src/main/resources/mapper/KioskMapper.xml
@@ -27,6 +27,7 @@
  *   - 250829 | yukyeong | findStatusById 추가 (키오스크 ONLINE 여부 확인용), lockKioskRow 추가 (행 잠금: startRun 시 동시 실행 방지용)
  *   - 250905 | sehui | 키오스크 단건 조회/전체 조회/등록/수정에 recycle_id 컬럼 추가
  *   - 250905 | sehui | 대시보드에서 조회할 키오스크 운영 상태별 개수 조회 기능 추가
+ *   - 250911 | yukyeong | 관리자 페이지 전용 updateStatus 쿼리 추가 (ONLINE/MAINT/OFFLINE 단순 변경)
  *
 -->
 
@@ -85,6 +86,15 @@
         FROM kiosk
         <include refid="kioskWhere"/>
     </select>
+
+    <!-- 1-4) 관리자 전용 상태 변경 (조건 없이 단순 변경) -->
+    <update id="updateStatus">
+        UPDATE kiosk
+        SET status = #{status},
+            updated_at = NOW()
+        WHERE kiosk_id = #{kioskId}
+          AND is_deleted = 0
+    </update>
 
 
     <!-- 2-1) 등록 -->

--- a/backend/petcoin/src/main/resources/mapper/RecycleStatsMapper.xml
+++ b/backend/petcoin/src/main/resources/mapper/RecycleStatsMapper.xml
@@ -11,6 +11,9 @@
     @history
      - 250902 | sehui | 전체 무인 회수기 수거 내역 조회 기능 추가
      - 250902 | sehui | 전체 무인 회수기 수 조회 기능 추가
+     - 250911 | yukyeong | 수거량 집계 로직 수정:
+                          - pet_collection_log 조인 제거 -> run 단위(COMPLETED 상태) 기준으로 total_pet 합산
+                          - 마지막 수거 시간은 run 종료 시각(ended_at) 기준으로 집계
 -->
 
 <mapper namespace="com.petcoin.mapper.RecycleStatsMapper">
@@ -22,15 +25,14 @@
             pr.recycle_name AS recycleName,
             pr.address AS address,
             k.status AS status,
-            COALESCE(SUM(kr.total_pet),0) AS totalCount,
-            MAX(pcl.created_at) AS lastCollection
+            COALESCE(SUM(CASE WHEN kr.status = 'COMPLETED' THEN kr.total_pet END),0) AS totalCount,
+            MAX(CASE WHEN kr.status = 'COMPLETED' THEN kr.ended_at END) AS lastCollection
         FROM pet_recycle pr
-        JOIN kiosk k ON pr.recycle_id = k.recycle_id
-        LEFT JOIN kiosk_run kr ON k.kiosk_id = kr.kiosk_id
-        LEFT JOIN pet_collection_log pcl ON kr.run_id = pcl.run_id
+                 JOIN kiosk k ON pr.recycle_id = k.recycle_id
+                 LEFT JOIN kiosk_run kr ON k.kiosk_id = kr.kiosk_id
         GROUP BY pr.recycle_id, pr.recycle_name, pr.address, k.status
         ORDER BY pr.recycle_name
-        LIMIT #{amount} OFFSET #{offset}
+            LIMIT #{amount} OFFSET #{offset}
     </select>
 
     <!-- 전체 무인 회수기 수 조회 -->

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,8 +1,8 @@
 # 스프링부트 API (회원/JWT/포인트/세션 등)
-REACT_APP_API_URL=http://localhost:8080
+# REACT_APP_API_URL=http://localhost:8080
 
 # 아이패드 API (키오스크 화면)
-# REACT_APP_API_URL=http://192.168.10.72:8080
+REACT_APP_API_URL=http://192.168.10.72:8080
 
 # 라즈베리파이 API (컨베이어/AI 요청/결과)
 REACT_APP_PI_API_URL=http://192.168.10.245:5000

--- a/frontend/src/admin/components/AdminDashboard.js
+++ b/frontend/src/admin/components/AdminDashboard.js
@@ -12,6 +12,7 @@
  *   - kioskLogs: 키오스크 로그 데이터
  *   - memberData: 회원 데이터
  *   - refundRequests: 환급 요청 데이터
+ *   - recycleStats: 무인 회수기 수거 내역 데이터
  *   - noticeData: 공지사항 데이터
  *   - selectedKiosk: 현재 선택된 키오스크 ID ('all' 또는 숫자)
  *   - selectedLogType: 현재 선택된 로그 유형
@@ -38,11 +39,17 @@
  *   - 250910 | sehui | 포인트 환급 요청 필터링 상태 변수 생성
  *   - 250910 | sehui | 대시보트 통계 조회 상태 변수와 함수 생성
  *   - 250910 | sehui | 공지사항 관련 변수와 함수 삭제
+ *   - 250911 | yukyeong | 수거 내역(무인 회수기 통계) 상태/조회(useEffect, state, 필터링 함수) 및 CollectionHistoryTab 연동 추가
+ *   - 250911 | yukyeong | 키오스크 상태 변경 로직 개선: updateKioskStatus API 연동(낙관적 업데이트 → 실패 시 롤백) 추가
+ *   - 250911 | yukyeong | 키오스크 상태 OFFLINE(미운영) 지원: handleKioskStatusChange가 'OFFLINE' 값도 그대로 서버에 전달/롤백하도록 허용(로컬 상태 업데이트 포함)
+ *   - 250912 | yukyeong | 대시보드 탭 진입 시 getKioskRuns 로드 추가(오늘 기준 수용량 계산용 로그)
+ *   - 250912 | yukyeong | DashboardTab에 kioskRuns 전달
  */
 
-import { getKiosks, getKioskRuns, updateKiosk, getTotal } from '../../api/admin.js';
+import { getKiosks, getKioskRuns, updateKiosk, getTotal, updateKioskStatus } from '../../api/admin.js';
 import { getAllMembers, getMemberDetail } from '../../api/admin.js';
 import { getPointRequests, getPointRequestById, processPointRequest } from '../../api/admin.js';
+import { getRecycleStats } from '../../api/admin.js';
 import React, { useState, useEffect } from 'react';
 
 // AdminDashboard.js에서
@@ -66,6 +73,8 @@ function AdminDashboard({ onNavigateToMain }) {
     const [refundRequests, setRefundRequests] = useState([]);       //포인트 환급 요청 데이터 (REQ-004, REQ-005)
     const [dashboardStats, setDashboardStats] = useState([]);   //대시보드 통계 데이터 (REQ-001)
     const [pageInfo, setPageInfo] = useState([]);       //페이지 정보
+    const [recycleStats, setRecycleStats] = useState([]);
+
 
     // ========== 상태 관리 ==========
     const [currentTime, setCurrentTime] = useState('');
@@ -165,11 +174,34 @@ function AdminDashboard({ onNavigateToMain }) {
     useEffect(() => {
         getTotal()
             .then(total => {
-                    console.log("🏠 대시보드 통계 조회");
+                console.log("🏠 대시보드 통계 조회");
                 setDashboardStats(total.data)
             })
             .catch(err => console.error("⚠️ 대시보드 통계 조회 실패", err))
     }, []);
+
+    // 수거 내역 불러오기
+    useEffect(() => {
+        const params = { pageNum: 1, amount: 10 };
+        getRecycleStats(params)
+            .then(res => setRecycleStats(res.list))
+            .catch(err => console.error("⚠️ 수거 내역 조회 실패", err));
+    }, []);
+
+    // 대시보드 들어올 때 로그 한번 로드
+    useEffect(() => {
+        if (activeTab !== 'dashboard') return;
+        let alive = true;
+        (async () => {
+            try {
+                const { list } = await getKioskRuns({ pageNum: 1, amount: 500 });
+                if (alive) setKioskLogs(list || []);
+            } catch (e) {
+                if (alive) setKioskLogs([]);
+            }
+        })();
+        return () => { alive = false; };
+    }, [activeTab]);
 
     // ========== 이벤트 핸들러 함수들 ==========
 
@@ -188,9 +220,9 @@ function AdminDashboard({ onNavigateToMain }) {
                 console.log("✅ 처리 결과:", res.data.message);
                 console.log("✅ 포인트 차감 여부:", res.data.pointDeducted);
 
-                setRefundRequests(prev => 
-                    prev.map(request => 
-                        request.requestId === refundId 
+                setRefundRequests(prev =>
+                    prev.map(request =>
+                        request.requestId === refundId
                             ? {
                                 ...request,
                                 requestStatus: action,
@@ -200,11 +232,11 @@ function AdminDashboard({ onNavigateToMain }) {
                             : request
                     )
                 );
-                
+
                 //승인 시 회원 포인트 차감
-                if(action === 'APPROVED') {
+                if (action === 'APPROVED') {
                     const request = refundRequests.find(req => req.requestId === refundId);
-                    if(request) {
+                    if (request) {
                         setMemberData(prev =>
                             prev.map(member =>
                                 member.memberId === request.memberId
@@ -224,31 +256,22 @@ function AdminDashboard({ onNavigateToMain }) {
     /**
      * 키오스크 상태 변경
      */
-    const handleKioskStatusChange = (kioskId, newStatus) => {
+    const handleKioskStatusChange = async (kioskId, newStatus) => {
+        // 낙관적 업데이트
+        const prevData = [...kioskData];
         setKioskData(prev =>
             prev.map(kiosk =>
-                kiosk.kioskId === kioskId
-                    ? { ...kiosk, status: newStatus }
-                    : kiosk
+                kiosk.kioskId === kioskId ? { ...kiosk, status: newStatus } : kiosk
             )
         );
-
         // 상태 변경 로그 추가
-        const kiosk = kioskData.find(k => k.kioskId === kioskId);
-        if (kiosk) {
-            const newLog = {
-                id: `LOG${Date.now()}`,
-                kioskId: kioskId,
-                kioskName: kiosk.name,
-                timestamp: new Date().toISOString(),
-                type: 'system',
-                message: `상태 변경: ${newStatus === 'ONLINE' ? '운영중' : '점검중'}`,
-                userId: null,
-                userName: null,
-                details: `status_change: ${kiosk.status} -> ${newStatus}`,
-                level: 'info'
-            };
-            setKioskLogs(prev => [newLog, ...prev]);
+        try {
+            await updateKioskStatus(kioskId, newStatus); // API 호출
+            console.log(`✅ 상태 변경 성공: ${kioskId} → ${newStatus}`);
+        } catch (e) {
+            console.error("⚠️ 상태 변경 실패", e);
+            setKioskData(prevData); // 실패 시 롤백
+            alert("상태 변경 실패");
         }
     };
 
@@ -294,6 +317,12 @@ function AdminDashboard({ onNavigateToMain }) {
         // endedAt > startedAt > timestamp 순으로 정렬키 선택
         const ts = l => new Date(l.endedAt ?? l.startedAt ?? l.timestamp ?? 0).getTime();
         return [...logs].sort((a, b) => ts(b) - ts(a));
+    };
+
+    const getFilteredRecycleStats = () => {
+        return selectedKiosk === 'all'
+            ? recycleStats
+            : recycleStats.filter(kiosk => kiosk.recycleId === Number(selectedKiosk));
     };
 
     // ========== 렌더링 ==========
@@ -369,15 +398,16 @@ function AdminDashboard({ onNavigateToMain }) {
                         dashboardStats={dashboardStats}
                         setDashboardStats={setDashboardStats}
                         kioskData={kioskData}
+                        kioskRuns={kioskLogs}
                     />
                 )}
 
                 {activeTab === 'collection' && (
                     <CollectionHistoryTab
-                        kioskData={kioskData}
+                        kioskData={recycleStats}
                         selectedKiosk={selectedKiosk}
                         setSelectedKiosk={setSelectedKiosk}
-                        getFilteredKioskData={getFilteredKioskData}
+                        getFilteredKioskData={getFilteredRecycleStats}
                     />
                 )}
 

--- a/frontend/src/admin/pages/CollectionHistoryTab.js
+++ b/frontend/src/admin/pages/CollectionHistoryTab.js
@@ -1,4 +1,32 @@
+/**
+ * CollectionHistoryTab.js
+ * - 관리자 페이지 수거 내역 탭 컴포넌트
+ *
+ * 주요 기능:
+ *   - 무인 회수기(재활용기) 수거 내역 표시
+ *   - 드롭다운으로 특정 수거기 선택 (전체/단일)
+ *   - 총 수거량, 마지막 수거 시각, 경과 시간 표시
+ *   - 위치 정보 표시
+ *
+ * @fileName : CollectionHistoryTab.js
+ * @author   : yukyeong
+ * @since    : 250911
+ * @history
+ *   - 250911 | yukyeong | 무인 회수기 수거 내역 전용 컴포넌트 구현
+ *   - 250911 | yukyeong | recycleId/recycleName 기반 드롭다운 및 카드 렌더링 적용
+ *   - 250911 | yukyeong | 총 수거량(totalCount), 마지막 수거 시각(lastCollection) 표시 추가
+ *   - 250911 | yukyeong | 경과 시간 계산 로직 추가 (분/시간/일 단위 표시)
+ *   - 250911 | yukyeong | todayCollection, capacity, 센서 데이터(온도/습도/오류) 섹션 주석 처리
+ *   - 250911 | yukyeong | ONLINE/MAINT 상태를 뱃지(`status-badge`) 스타일로 표시하도록 수정
+ */
+
 import React from 'react';
+
+const statusToCss = (s) => {
+    if (s === 'ONLINE') return 'active';
+    if (s === 'MAINT') return 'maintenance';
+    return 'unknown';
+};
 
 function CollectionHistoryTab({ kioskData, selectedKiosk, setSelectedKiosk, getFilteredKioskData }) {
     return (
@@ -12,22 +40,26 @@ function CollectionHistoryTab({ kioskData, selectedKiosk, setSelectedKiosk, getF
                 >
                     <option value="all">전체 수거함</option>
                     {kioskData.map(kiosk => (
-                        <option key={kiosk.id} value={kiosk.id}>{kiosk.name}</option>
+                        <option key={kiosk.recycleId} value={kiosk.recycleId}>
+                            {kiosk.recycleName ?? kiosk.name}
+                        </option>
                     ))}
                 </select>
             </div>
 
             <div className="collection-stats">
                 {getFilteredKioskData().map(kiosk => (
-                    <div key={kiosk.id} className="collection-card">
+                    <div key={kiosk.name} className="collection-card">
                         <div className="collection-card-header">
-                            <h3>📍 {kiosk.name}</h3>
-                            <span className={`status-badge ${kiosk.status}`}>
-                                {kiosk.status === 'active' ? '운영중' : '점검중'}
+                            <h3>📍 {kiosk.recycleName ?? kiosk.name}</h3>
+                            <span className={`status-badge ${statusToCss(kiosk.status)}`}>
+                                {kiosk.status === 'ONLINE' ? '운영중' 
+                                    : kiosk.status === 'MAINT' ? '점검중' 
+                                    : '알수없음'}
                             </span>
                         </div>
 
-                        <div className="capacity-info">
+                        {/* <div className="capacity-info">
                             <div className="capacity-header">
                                 <span>현재 수용량</span>
                                 <span>
@@ -41,29 +73,51 @@ function CollectionHistoryTab({ kioskData, selectedKiosk, setSelectedKiosk, getF
                                     style={{ width: `${(kiosk.currentCount / kiosk.capacity) * 100}%` }}
                                 ></div>
                             </div>
-                        </div>
+                        </div> */}
 
                         <div className="collection-metrics">
-                            <div className="metric">
+                            {/* <div className="metric">
                                 <span className="metric-label">오늘 수거량</span>
                                 <span className="metric-value">{kiosk.todayCollection}개</span>
-                            </div>
+                            </div> */}
                             <div className="metric">
                                 <span className="metric-label">총 수거량</span>
-                                <span className="metric-value">{kiosk.totalCollection.toLocaleString()}개</span>
+                                <span className="metric-value">{(kiosk.totalCount ?? 0).toLocaleString()}개</span>
                             </div>
                             <div className="metric">
                                 <span className="metric-label">마지막 수거</span>
                                 <span className="metric-value">
-                                    {new Date(kiosk.lastCollection).toLocaleString('ko-KR', {
-                                        month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'
-                                    })}
+                                    {kiosk.lastCollection
+                                        ? new Date(kiosk.lastCollection).toLocaleString('ko-KR', {
+                                            month: '2-digit',
+                                            day: '2-digit',
+                                            hour: '2-digit',
+                                            minute: '2-digit'
+                                        })
+                                        : '-'}
+                                </span>
+                            </div>
+                            {/* 🔽 여기 추가 */}
+                            <div className="metric">
+                                <span className="metric-label">경과 시간</span>
+                                <span className="metric-value">
+                                    {kiosk.lastCollection
+                                        ? (() => {
+                                            const diffMs = new Date() - new Date(kiosk.lastCollection);
+                                            const diffMins = Math.floor(diffMs / 60000);
+                                            if (diffMins < 60) return `${diffMins}분 전`;
+                                            const diffHours = Math.floor(diffMins / 60);
+                                            if (diffHours < 24) return `${diffHours}시간 전`;
+                                            const diffDays = Math.floor(diffHours / 24);
+                                            return `${diffDays}일 전`;
+                                        })()
+                                        : '-'}
                                 </span>
                             </div>
                         </div>
 
                         <div className="system-info">
-                            <div className="info-item">
+                            {/* <div className="info-item">
                                 <span>🌡️ 온도: {kiosk.temperature}°C</span>
                             </div>
                             <div className="info-item">
@@ -71,6 +125,9 @@ function CollectionHistoryTab({ kioskData, selectedKiosk, setSelectedKiosk, getF
                             </div>
                             <div className="info-item">
                                 <span>⚠️ 오류: {kiosk.errorCount}건</span>
+                            </div> */}
+                            <div className="info-item">
+                                <span>📍 위치: {kiosk.address}</span>
                             </div>
                         </div>
                     </div>

--- a/frontend/src/admin/pages/DashboardTab.js
+++ b/frontend/src/admin/pages/DashboardTab.js
@@ -14,14 +14,51 @@
  *   - 250909 | yukyeong | 상태 요약 카운트(운영중/점검중) 필터 로직을 ONLINE/MAINT 기준으로 수정
  *   - 250909 | yukyeong | 키(key) 필드를 kioskId 로 통일
  *   - 250910 | sehui | 통계 카드 데이터 연결
+ *   - 250911 | yukyeong | 미운영 상태 표시 추가: statusToCss에 OFFLINE→'inactive' 매핑, 카드/뱃지 라벨에 '미운영' 분기
+ *   - 250912 | yukyeong | 수용량(오늘 기준) 표시/막대 추가: CAPACITY_DEFAULT=300, cap/remain/usedPct 계산, OFFLINE일 때 막대 숨김
  * 
  */
 
 import React from 'react';
 
-const statusToCss = (s) => s === 'ONLINE' ? 'active' : s === 'MAINT' ? 'maintenance' : 'unknown';
+const CAPACITY_DEFAULT = 300; // 임시 총 수용량(병 개수)
 
-function DashboardTab({ dashboardStats, kioskData }) {
+const statusToCss = (s) => {
+    if (s === 'ONLINE') return 'active';
+    if (s === 'MAINT') return 'maintenance';
+    if (s === 'OFFLINE') return 'inactive';
+    return 'unknown';
+};
+
+
+function DashboardTab({ dashboardStats = {}, kioskData = [], kioskRuns = [] }) {
+
+    // ✅ 특정 키오스크의 "오늘" 병 합계 + 건수만 계산 (로컬 날짜 기준, KST 고려 X: 가장 단순)
+    const getTodayStats = (kiosk) => {
+        const id = kiosk.recycleId ?? kiosk.kioskId ?? kiosk.id;
+        const today = new Date();
+
+        let bottles = 0;
+        let sessions = 0;
+
+        for (const r of kioskRuns) {
+            const runId = r.recycleId ?? r.kioskId ?? r.id;
+            if (runId !== id) continue;
+            if (r.status !== 'COMPLETED') continue;
+
+            const ended = new Date(r.endedAt ?? r.ended_at);
+            if (
+                ended.getFullYear() !== today.getFullYear() ||
+                ended.getMonth() !== today.getMonth() ||
+                ended.getDate() !== today.getDate()
+            ) continue;
+
+            bottles += Number(r.total_pet ?? r.totalPet ?? 0) || 0; // 병 개수
+            sessions += 1;                                          // 런 건수
+        }
+
+        return { bottles, sessions };
+    };
     return (
         <div className="dashboard-section">
             <h2>대시보드</h2>
@@ -64,7 +101,7 @@ function DashboardTab({ dashboardStats, kioskData }) {
 
             {/* 키오스크 현황 */}
             <div className="kiosk-overview">
-                <h3>수거함 현황</h3>
+                <h3>키오스크 현황</h3>
                 <div className="kiosk-status-summary">
                     <div className="status-item">
                         <span className="status-label">운영중</span>
@@ -80,29 +117,48 @@ function DashboardTab({ dashboardStats, kioskData }) {
                     </div>
                 </div>
                 <div className="kiosk-grid">
-                    {kioskData.map(kiosk => (
-                        <div key={kiosk.kioskId} className={`kiosk-card ${statusToCss(kiosk.status)}`}>
-                            <div className="kiosk-header">
-                                <h4>{kiosk.name}</h4>
-                                <span className={`status-badge ${statusToCss(kiosk.status)}`}>
-                                    {kiosk.status === 'ONLINE' ? '운영중'
-                                        : kiosk.status === 'MAINT' ? '점검중'
-                                            : kiosk.status}
-                                </span>
+                    {kioskData.map(kiosk => {
+                        const { bottles, sessions } = getTodayStats(kiosk);
+
+                        // 추가
+                        const cap = kiosk.capacity ?? CAPACITY_DEFAULT;            // BE가 주면 그 값, 없으면 300
+                        const remain = Math.max(cap - bottles, 0);                 // 오늘 투입량 기준 잔여
+                        const remainPct = cap ? Math.round((remain / cap) * 100) : 0;
+                        const isInactive = kiosk.status === 'OFFLINE';
+
+                        const usedPct = cap ? Math.min(100, Math.max(0, Math.round((bottles / cap) * 100))) : 0; // 사용률
+                        const fillClass = usedPct < 60 ? 'ok' : usedPct < 85 ? 'warn' : 'crit';
+
+                        return (
+                            <div key={kiosk.kioskId} className={`kiosk-card ${statusToCss(kiosk.status)}`}>
+                                <div className="kiosk-header">
+                                    <h4>{kiosk.name}</h4>
+                                    <span className={`status-badge ${statusToCss(kiosk.status)}`}>
+                                        {kiosk.status === 'ONLINE' ? '운영중'
+                                            : kiosk.status === 'MAINT' ? '점검중'
+                                                : kiosk.status === 'OFFLINE' ? '미운영'
+                                                    : '-'}
+                                    </span>
+                                </div>
+
+                                <div className="kiosk-stats">
+                                    <span>
+                                        수용량: {isInactive ? '-' : `${remain}/${cap} (${remainPct}%)`}
+                                        <small style={{ marginLeft: 6, color: '#94a3b8' }}>오늘 기준</small>
+                                    </span>
+                                    <span>오늘: {bottles}개 · {sessions}건</span>
+                                </div>
+
+                                {!isInactive && (
+                                    <div className="capacity-bar">
+                                        <div className={`capacity-fill ${fillClass}`} style={{ width: `${usedPct}%` }} />
+                                    </div>
+                                )}
+
+                                <div className="kiosk-location">{kiosk.location}</div>
                             </div>
-                            <div className="kiosk-stats">
-                                <span>수용량: {kiosk.currentCount}/{kiosk.capacity}</span>
-                                <span>오늘: {kiosk.todayCollection}개</span>
-                            </div>
-                            <div className="capacity-bar">
-                                <div
-                                    className="capacity-fill"
-                                    style={{ width: `${(kiosk.currentCount / kiosk.capacity) * 100}%` }}
-                                ></div>
-                            </div>
-                            <div className="kiosk-location">{kiosk.location}</div>
-                        </div>
-                    ))}
+                        );
+                    })}
                 </div>
             </div>
         </div>

--- a/frontend/src/admin/styles/AdminDashboard.css
+++ b/frontend/src/admin/styles/AdminDashboard.css
@@ -39,7 +39,8 @@
     font-weight: 600;
     color: #374151;
     font-size: 14px;
-    text-align: center; /* 이 줄을 추가 */
+    text-align: center;
+    /* 이 줄을 추가 */
 }
 
 .board-table-body {
@@ -56,7 +57,8 @@
     transition: background-color 0.2s ease;
     align-items: center;
     font-size: 14px;
-    text-align: center; /* 이 줄을 추가 */
+    text-align: center;
+    /* 이 줄을 추가 */
 }
 
 .board-row:hover {
@@ -157,7 +159,8 @@
 .action-buttons {
     display: flex;
     gap: 8px;
-    flex-direction: row; /* 가로로 나란히 배치 */
+    flex-direction: row;
+    /* 가로로 나란히 배치 */
     justify-content: center;
     align-items: center;
 }
@@ -166,13 +169,15 @@
     background-color: #22c55e;
     color: white;
     border: none;
-    padding: 8px 12px; /* 패딩 증가 */
+    padding: 8px 12px;
+    /* 패딩 증가 */
     border-radius: 6px;
     font-size: 12px;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s ease;
-    min-width: 50px; /* 최소 너비 설정 */
+    min-width: 50px;
+    /* 최소 너비 설정 */
 }
 
 .approve-btn-small:hover {
@@ -183,13 +188,15 @@
     background-color: #ef4444;
     color: white;
     border: none;
-    padding: 8px 12px; /* 패딩 증가 */
+    padding: 8px 12px;
+    /* 패딩 증가 */
     border-radius: 6px;
     font-size: 12px;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s ease;
-    min-width: 50px; /* 최소 너비 설정 */
+    min-width: 50px;
+    /* 최소 너비 설정 */
 }
 
 .reject-btn-small:hover {
@@ -278,14 +285,16 @@
     color: #1e293b;
     font-weight: 600;
     font-size: 15px;
-    margin-right: 20px;         /* 오른쪽에 간격 추가 */
+    margin-right: 20px;
+    /* 오른쪽에 간격 추가 */
 }
 
 .history-amount {
     color: #ff7849;
     font-weight: 700;
     font-size: 14px;
-    margin-right: 20px;         /* 오른쪽에 간격 추가 */
+    margin-right: 20px;
+    /* 오른쪽에 간격 추가 */
 }
 
 .history-status {
@@ -359,6 +368,10 @@
 
 .kiosk-status-card.maintenance {
     border-left: 4px solid #ef4444;
+}
+
+.kiosk-status-card.inactive {
+  border-left: 4px solid #94a3b8;
 }
 
 .status-card-header {
@@ -459,14 +472,20 @@
 
 .logs-header {
     display: grid;
-    grid-template-columns: 120px 150px 100px 2fr 120px 1fr;
-    gap: 15px;
+    grid-template-columns: 1.5fr 2fr 1fr 2fr 1.5fr;
+    /* 시간 | 키오스크 | 상태 | 메시지 | 사용자 */
+    gap: 25px;
+    /* 간격 줄이기 */
     padding: 15px;
     background-color: #f8fafc;
     border-bottom: 1px solid #e2e8f0;
     font-weight: 600;
     color: #374151;
     font-size: 13px;
+    align-items: center;
+    /* 세로 중앙 정렬 */
+    text-align: center;
+    /* 모든 컬럼 가운데 정렬 */
 }
 
 .logs-body {
@@ -476,18 +495,56 @@
 
 .log-row {
     display: grid;
-    grid-template-columns: 120px 150px 100px 2fr 120px 1fr;
-    gap: 15px;
+    grid-template-columns: 1.5fr 2fr 1fr 2fr 1.5fr;
+    /* 시간 | 키오스크 | 상태 | 메시지 | 사용자 */
+    gap: 25px;
+    /* 간격 줄이기 */
     padding: 15px;
     border-bottom: 1px solid #f1f5f9;
     transition: background-color 0.2s ease;
     align-items: center;
     font-size: 13px;
+    text-align: center;
+    /* 가운데 정렬 */
 }
 
-.log-row:hover {
-    background-color: #fff7f5;
+.log-row {
+    transition: background-color 0.2s ease; /* hover 시 부드럽게 */
 }
+
+/* 완료(Completed) → 연한 초록 */
+.log-row.completed {
+    background-color: #f0fdf4;
+    border-left: 4px solid #22c55e;
+}
+
+/* 실행중(Running) → 연한 파랑 */
+.log-row.running {
+    background-color: #eff6ff;
+    border-left: 4px solid #3b82f6;
+}
+
+/* 취소(Cancelled) → 연한 빨강 */
+.log-row.cancelled {
+    background-color: #fef2f2;
+    border-left: 4px solid #ef4444;
+}
+
+.log-row.completed:hover {
+    background-color: #dcfce7;
+}
+
+/* 연한 초록 */
+.log-row.running:hover {
+    background-color: #dbeafe;
+}
+
+/* 연한 파랑 */
+.log-row.cancelled:hover {
+    background-color: #fee2e2;
+}
+
+/* 연한 빨강 */
 
 .log-row:last-child {
     border-bottom: none;
@@ -512,6 +569,7 @@
     color: #64748b;
     font-weight: 500;
     font-family: monospace;
+    white-space: nowrap;
 }
 
 .log-kiosk {
@@ -520,11 +578,21 @@
 }
 
 .log-type {
-    padding: 4px 8px;
+    display: flex;
+    /* flex 사용 */
+    justify-content: center;
+    /* 가로 중앙 */
+    align-items: center;
+    /* 세로 중앙 */
+    padding: 6px 12px;
     border-radius: 12px;
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 600;
     text-align: center;
+    min-width: 60px;
+    /* 균일한 폭 */
+    margin: 0 auto;
+    /* 수평 중앙 */
 }
 
 .log-type.collection {
@@ -550,11 +618,14 @@
 .log-message {
     color: #374151;
     font-weight: 500;
+    text-align: left;
+    padding-left: 60px;
 }
 
 .log-user {
     color: #64748b;
     font-style: italic;
+    text-align: center;
 }
 
 
@@ -620,31 +691,31 @@
     .summary-cards {
         grid-template-columns: repeat(2, 1fr);
     }
-    
+
     .collection-stats {
         grid-template-columns: 1fr;
     }
-    
+
     .kiosk-grid {
         grid-template-columns: repeat(2, 1fr);
     }
-    
+
     .kiosk-status-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .board-table-header,
     .board-row {
         grid-template-columns: 50px 150px 100px 150px 120px 80px 120px;
         font-size: 13px;
     }
-    
+
     /* 버튼은 가로로 유지 */
     .action-buttons {
         flex-direction: row;
         gap: 6px;
     }
-    
+
     .approve-btn-small,
     .reject-btn-small {
         padding: 6px 10px;
@@ -659,40 +730,40 @@
         gap: 15px;
         text-align: center;
     }
-    
+
     .admin-info {
         flex-direction: column;
         gap: 10px;
     }
-    
+
     .collection-header,
     .kiosk-header {
         flex-direction: column;
         gap: 15px;
         align-items: stretch;
     }
-    
+
     .members-summary,
     .refund-summary-board {
         flex-direction: column;
         align-items: center;
     }
-    
+
     .collection-metrics {
         grid-template-columns: 1fr;
     }
-    
+
     .system-info {
         flex-direction: column;
         gap: 10px;
     }
-    
+
     .logs-header,
     .log-row {
         grid-template-columns: 1fr;
         gap: 5px;
     }
-    
+
     .logs-header span,
     .log-row span {
         padding: 8px;
@@ -704,58 +775,58 @@
     .admin-dashboard {
         font-size: 14px;
     }
-    
+
     .admin-header {
         padding: 15px 20px;
     }
-    
+
     .admin-main {
         padding: 20px;
     }
-    
+
     .nav-tabs {
         flex-wrap: wrap;
         justify-content: center;
     }
-    
+
     .nav-tab {
         padding: 12px 20px;
         font-size: 14px;
     }
-    
+
     .summary-cards {
         grid-template-columns: 1fr;
     }
-    
+
     .kiosk-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .admin-main h2 {
         font-size: 24px;
         text-align: center;
     }
-    
+
     .table-header,
     .table-row {
         grid-template-columns: 1fr;
         gap: 5px;
     }
-    
+
     .table-header span,
     .table-row span,
     .table-row div {
         padding: 8px;
         border-bottom: 1px solid #f1f5f9;
     }
-    
+
     .board-table-header,
     .board-row {
         grid-template-columns: 1fr;
         gap: 5px;
         text-align: left;
     }
-    
+
     .board-table-header span,
     .board-row span {
         padding: 8px;
@@ -767,44 +838,44 @@
     .admin-title-section h1 {
         font-size: 20px;
     }
-    
+
     .admin-title-section p {
         font-size: 12px;
     }
-    
+
     .summary-card {
         flex-direction: column;
         text-align: center;
         padding: 20px;
     }
-    
+
     .card-icon {
         width: 50px;
         height: 50px;
         font-size: 30px;
     }
-    
+
     .kiosk-status-summary {
         flex-direction: column;
         gap: 15px;
     }
-    
+
     .board-header {
         flex-direction: column;
         gap: 15px;
         text-align: center;
     }
-    
+
     .board-controls {
         flex-direction: column;
         width: 100%;
     }
-    
+
     .status-filter,
     .refresh-btn {
         width: 100%;
     }
-    
+
     .log-filters {
         flex-direction: column;
         gap: 10px;
@@ -843,6 +914,7 @@
         opacity: 0;
         transform: translateY(20px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);
@@ -894,7 +966,7 @@
     .admin-dashboard {
         background-color: white;
     }
-    
+
     .admin-header,
     .admin-nav,
     .back-button,
@@ -906,12 +978,12 @@
     .page-btn {
         display: none;
     }
-    
+
     .admin-main {
         padding: 20px;
         overflow: visible;
     }
-    
+
     .summary-card,
     .kiosk-card,
     .collection-card,
@@ -964,7 +1036,8 @@
     font-size: 28px;
     font-weight: 700;
     margin: 0 0 3px 0;
-    color: white; /* 흰색으로 변경 */
+    color: white;
+    /* 흰색으로 변경 */
 }
 
 .admin-title-section p {
@@ -1179,6 +1252,10 @@
     color: #ef4444;
 }
 
+.status-count.inactive {     /* 미운영 */
+    color: #9ca3af;          /* 회색 계열 */
+}
+
 .status-count.total {
     color: #3b82f6;
 }
@@ -1204,6 +1281,11 @@
 .kiosk-card.maintenance {
     border-left: 4px solid #ef4444;
     background-color: #fef2f2;
+}
+
+.kiosk-card.inactive {
+  border-left: 4px solid #94a3b8;   /* 회색 보더 */
+  background-color: #f3f4f6;        /* 연회색 배경 */
 }
 
 .kiosk-card:hover {
@@ -1240,6 +1322,11 @@
 .status-badge.maintenance {
     background-color: #fee2e2;
     color: #991b1b;
+}
+
+.status-badge.inactive {
+  background-color: #e5e7eb; /* 회색 배경 */
+  color: #6b7280;            /* 회색 글자 */
 }
 
 .kiosk-stats {
@@ -1410,7 +1497,7 @@
 
 .system-info {
     display: flex;
-    justify-content: space-around;
+    justify-content: flex-start;
     padding: 15px;
     background-color: #f8fafc;
     border-radius: 8px;
@@ -1490,7 +1577,8 @@
     font-weight: 600;
     color: #374151;
     font-size: 14px;
-    text-align: center; /* 이 줄을 추가 */
+    text-align: center;
+    /* 이 줄을 추가 */
 }
 
 
@@ -1504,7 +1592,8 @@
     transition: background-color 0.2s ease;
     align-items: center;
     font-size: 14px;
-    text-align: center; /* 이 줄을 추가 */
+    text-align: center;
+    /* 이 줄을 추가 */
 }
 
 .table-row:hover {
@@ -1698,11 +1787,15 @@
 /* 헤더 내용 컨테이너 - 좌우 정렬과 최대 너비 설정 */
 .mypage-header .container {
     display: flex;
-    justify-content: space-between;  /* 좌우 끝 정렬 */
+    justify-content: space-between;
+    /* 좌우 끝 정렬 */
     align-items: center;
-    max-width: 1400px;               /* 최대 너비 제한 */
-    margin: 0 auto;                  /* 가운데 정렬 */
-    padding: 0 30px;                 /* 좌우 여백 */
+    max-width: 1400px;
+    /* 최대 너비 제한 */
+    margin: 0 auto;
+    /* 가운데 정렬 */
+    padding: 0 30px;
+    /* 좌우 여백 */
 }
 
 /* 왼쪽 로고 영역 */
@@ -1719,9 +1812,12 @@
 
 /* 로고 이미지 스타일 */
 .logo-img {
-    height: 80px;           /* 로고 높이 설정 */
-    width: auto;            /* 비율에 맞게 너비 자동 조정 */
-    object-fit: contain;    /* 이미지 비율 유지 */
+    height: 80px;
+    /* 로고 높이 설정 */
+    width: auto;
+    /* 비율에 맞게 너비 자동 조정 */
+    object-fit: contain;
+    /* 이미지 비율 유지 */
 }
 
 /* 오른쪽 사용자 정보 영역 */
@@ -1734,15 +1830,18 @@
 .user-profile {
     display: flex;
     align-items: center;
-    gap: 15px;  /* 아바타와 텍스트 사이 간격 */
+    gap: 15px;
+    /* 아바타와 텍스트 사이 간격 */
 }
 
 /* 프로필 아바타 - 원형 아이콘 */
 .profile-avatar {
     width: 50px;
     height: 50px;
-    background-color: #ff7849;  /* 브랜드 색상 배경 */
-    border-radius: 50%;         /* 완전한 원형 */
+    background-color: #ff7849;
+    /* 브랜드 색상 배경 */
+    border-radius: 50%;
+    /* 완전한 원형 */
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1753,8 +1852,10 @@
 /* 프로필 정보 텍스트 영역 - 세로 정렬 */
 .profile-info {
     display: flex;
-    flex-direction: column;  /* 세로로 배치 */
-    gap: 4px;               /* 이름과 상세정보 사이 간격 */
+    flex-direction: column;
+    /* 세로로 배치 */
+    gap: 4px;
+    /* 이름과 상세정보 사이 간격 */
 }
 
 /* 프로필 이름 스타일 */
@@ -1767,7 +1868,8 @@
 
 /* 프로필 상세 정보 (등급, 연속 참여일 등) */
 .profile-details {
-    color: #94a3b8;  /* 연한 회색 */
+    color: #94a3b8;
+    /* 연한 회색 */
     font-size: 14px;
     font-weight: 400;
     margin: 0;
@@ -1777,25 +1879,29 @@
 
 /* 태블릿 사이즈 (768px 이하) */
 @media (max-width: 768px) {
+
     /* 헤더를 세로 배치로 변경 */
     .mypage-header .container {
-        flex-direction: column;  /* 세로 배치 */
+        flex-direction: column;
+        /* 세로 배치 */
         gap: 15px;
-        text-align: center;      /* 가운데 정렬 */
-        padding: 0 20px;         /* 좌우 패딩 줄임 */
+        text-align: center;
+        /* 가운데 정렬 */
+        padding: 0 20px;
+        /* 좌우 패딩 줄임 */
     }
-    
+
     /* 사용자 프로필도 세로 배치 */
     .user-profile {
         flex-direction: column;
         gap: 10px;
     }
-    
+
     /* 프로필 정보 가운데 정렬 */
     .profile-info {
         text-align: center;
     }
-    
+
     /* 로고 이미지 크기 축소 */
     .logo-img {
         height: 32px;
@@ -1804,27 +1910,28 @@
 
 /* 모바일 사이즈 (480px 이하) */
 @media (max-width: 480px) {
+
     /* 헤더 패딩 줄임 */
     .mypage-header {
         padding: 15px 0;
     }
-    
+
     /* 아바타 크기 축소 */
     .profile-avatar {
         width: 40px;
         height: 40px;
         font-size: 20px;
     }
-    
+
     /* 텍스트 크기 축소 */
     .profile-name {
         font-size: 16px;
     }
-    
+
     .profile-details {
         font-size: 12px;
     }
-    
+
     .logo-text {
         font-size: 20px;
     }
@@ -2529,7 +2636,7 @@
     .notice-summary {
         grid-template-columns: repeat(2, 1fr);
     }
-    
+
     .notice-table-header,
     .notice-row {
         grid-template-columns: 60px 80px 2fr 100px 60px 80px 120px;
@@ -2544,24 +2651,24 @@
         text-align: center;
         gap: 20px;
     }
-    
+
     .notice-controls {
         flex-direction: column;
         gap: 15px;
     }
-    
+
     .search-section {
         margin-right: 0;
     }
-    
+
     .filter-section {
         justify-content: center;
     }
-    
+
     .detail-actions {
         justify-content: center;
     }
-    
+
     .form-row {
         flex-direction: column;
     }
@@ -2571,34 +2678,34 @@
     .notice-summary {
         grid-template-columns: 1fr;
     }
-    
+
     .notice-table-header,
     .notice-row {
         grid-template-columns: 1fr;
         gap: 5px;
         text-align: left;
     }
-    
+
     .notice-table-header span,
     .notice-row span {
         padding: 8px;
         border-bottom: 1px solid #f1f5f9;
     }
-    
+
     .notice-title-cell {
         justify-content: flex-start;
     }
-    
+
     .notice-actions {
         justify-content: flex-start;
         flex-wrap: wrap;
     }
-    
+
     .detail-meta {
         flex-direction: column;
         gap: 10px;
     }
-    
+
     .meta-item {
         justify-content: space-between;
         padding: 8px 0;
@@ -2610,38 +2717,38 @@
     .notice-title-section h2 {
         font-size: 24px;
     }
-    
+
     .create-notice-btn {
         width: 100%;
         text-align: center;
     }
-    
+
     .summary-item-notice {
         padding: 15px;
     }
-    
+
     .summary-item-notice .summary-value {
         font-size: 20px;
     }
-    
+
     .detail-title {
         font-size: 20px;
     }
-    
+
     .notice-form-header {
         flex-direction: column;
         gap: 10px;
         text-align: center;
     }
-    
+
     .notice-form-header h2 {
         font-size: 24px;
     }
-    
+
     .form-actions {
         flex-direction: column;
     }
-    
+
     .btn-cancel,
     .btn-submit {
         width: 100%;
@@ -2716,6 +2823,7 @@
 
 /* ========== 프린트 스타일 ========== */
 @media print {
+
     .notice-header,
     .notice-controls,
     .notice-actions,
@@ -2726,14 +2834,14 @@
     .create-notice-btn {
         display: none;
     }
-    
+
     .notice-table,
     .notice-detail-content,
     .notice-form {
         box-shadow: none;
         border: 1px solid #000;
     }
-    
+
     .notice-row {
         break-inside: avoid;
     }

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -17,6 +17,8 @@
  *   - getKioskRuns(criteria) : 키오스크 실행 세션 목록 조회 (페이징/검색 포함)
  *   - getKioskRun(runId) : 키오스크 실행 세션 단건 상세 조회
  *   - getTotal : 대시보드 통계 조회
+ *   - getRecycleStats(criteria) : 무인 회수기 수거 내역 조회 (페이징/검색 포함)
+ *   - updateKioskStatus(kioskId, status) : 키오스크 상태 변경 (ONLINE/MAINT/OFFLINE)
  *
  * 요청 경로는 AdminApiController와 1:1 매핑됨.
  *
@@ -29,6 +31,8 @@
  *   - 250909 | yukyeong | 키오스크 API 개선: getKiosks/getKioskRuns 응답 구조를 {list, pageInfo} 형태로 통일,
  *                         getKiosk/getKioskRun 단건 조회 시 null 가드 처리 추가
  *   - 250910 | sehui | 대시보드 API 함수 추가
+ *   - 250911 | yukyeong | 무인 회수기 수거 내역 조회 API 함수(getRecycleStats) 추가
+ *   - 250911 | yukyeong | 키오스크 상태 변경 API 함수(updateKioskStatus)
  */
 
 
@@ -99,5 +103,19 @@ export const getKioskRun = (runId) =>
         .then(r => r?.data?.kioskRun ?? null);
 
 /* 대시보드 */
-export const getTotal = () => 
+export const getTotal = () =>
     api.get(`/api/admin/dashboard`);
+
+
+// 수거 내역(무인 회수기 통계) 조회
+export const getRecycleStats = (params) =>
+    api.get('/api/admin/recycle/stats', { params })
+        .then(r => ({
+            list: r?.data?.statsList ?? [],
+            pageInfo: r?.data?.pageInfo ?? null,
+        }));
+
+
+// 키오스크 상태 변경 (ONLINE | MAINT | OFFLINE)
+export const updateKioskStatus = (kioskId, status) =>
+    api.put(`/api/admin/kiosk/${kioskId}/status`, { status });


### PR DESCRIPTION
< 관리자 페이지-키오스크 탭에서 로그 부분 메세지 삭제하고 상세정보를 메세지에 넣기 >
KioskTab.js 
- 로그 테이블에서 상세정보 칸 제거, detailsText 내용을 메시지 칸으로 이동하여 UI 단순화
- 로그 시간 포맷 수정: 날짜+시간을 한 줄로 표시하도록 locale 옵션 지정
AdminDashboard.css
css 부분 수정



< 관리자 페이지-수거내역 탭 기능 연결 >
1. admin.js : getRecycleStats(criteria) : 무인 회수기 수거 내역 조회 (페이징/검색 포함)
- 무인 회수기 수거 내역 조회 API 함수(getRecycleStats) 추가

2. AdminDashboard.js : recycleStats: 무인 회수기 수거 내역 데이터
- 수거 내역(무인 회수기 통계) 상태/조회(useEffect, state, 필터링 함수) 및 CollectionHistoryTab 연동 추가

3. CollectionHistoryTab.js : 무인 회수기(재활용기) 수거 내역 표시, 드롭다운으로 특정 수거기 선택 (전체/단일), 총 수거량, 마지막 수거 시각, 경과 시간 표시, 위치 정보 표시
- recycleId/recycleName 기반 드롭다운 및 카드 렌더링 적용
- 총 수거량(totalCount), 마지막 수거 시각(lastCollection) 표시 추가
- 경과 시간 계산 로직 추가 (분/시간/일 단위 표시)
- todayCollection, capacity, 센서 데이터(온도/습도/오류) 섹션 주석 처리

4. RecycleStatsMapper.xml
수거량 집계 로직 수정:
- pet_collection_log 조인 제거 → run 단위(COMPLETED 상태) 기준으로 total_pet 합산
- 마지막 수거 시간은 run 종료 시각(ended_at) 기준으로 집계

< 관리자 페이지-수거내역 탭 css 수정 >
1. 점검중 / 운영중 상태 뱃지 표시
CollectionHistoryTab.js
- ONLINE/MAINT 상태를 뱃지(`status-badge`) 스타일로 표시하도록 수정

2. 위치 부분 가운데 정렬이 아니라 왼쪽 정렬로 수정
AdminDashboard.css

< 관리자 페이지-키오스크 탭 상태표시 수정하면 DB에도 반영되도록 수정 >
1. KioskMapper
- 관리자 페이지 전용 updateStatus 메서드 추가 (키오스크 상태 단순 변경: ONLINE/MAINT/OFFLINE)

2. KioskMapper.xml
- 관리자 페이지 전용 updateStatus 쿼리 추가 (ONLINE/MAINT/OFFLINE 단순 변경)

3. KioskService
- 관리자 전용 키오스크 상태 변경(updateStatus) 기능 추가

4. KioskServiceImpl
- updateStatus 메서드 추가 (관리자 전용 상태 변경: ONLINE/MAINT/OFFLINE)

5. StatusUpdateRequest
- 프론트엔드에서 보낸 status 값을 매핑, 키오스크 상태 변경 요청 DTO 정의

6. AdminKioskApiController
- 키오스크 상태 변경 API 추가 (PUT /{kioskId}/status, 관리자 전용, ONLINE/MAINT/OFFLINE)

7. admin.js 
updateKioskStatus(kioskId, status) : 키오스크 상태 변경 (ONLINE/MAINT/OFFLINE)
- 키오스크 상태 변경 API 함수(updateKioskStatus)

8. AdminDashboard.js
- 키오스크 상태 변경 로직 개선: updateKioskStatus API 연동(낙관적 업데이트 → 실패 시 롤백) 추가

9. KioskTab.js
상태 드롭다운에 OFFLINE(미운영) 옵션 추가 및 statusToCss에 offline 매핑 반영

< 미운영 css 추가 >
1. KioskTab.js
- 미운영 상태 도입: 드롭다운에 OFFLINE(미운영) 옵션 추가, statusToCss에 OFFLINE→'inactive' 매핑

2. DashboardTab.js
- 미운영 상태 표시 추가: statusToCss에 OFFLINE→'inactive' 매핑, 카드/뱃지 라벨에 '미운영' 분기

3. AdminDashboard.css 수정

+ AdminDashboard.js
키오스크 상태 OFFLINE(미운영) 지원: handleKioskStatusChange가 'OFFLINE' 값도 그대로 서버에 전달/롤백하도록 허용(로컬 상태 업데이트 포함)


< 관리자 페이지-대시보드 수용량 부분 수정 >
수거함 -> 키오스크로 이름 변경
1. AdminDashboard.js
- 대시보드 탭 진입 시 getKioskRuns 로드 추가(오늘 기준 수용량 계산용 로그)
- DashboardTab에 kioskRuns 전달

2. DashboardTab.js
- 수용량(오늘 기준) 표시/막대 추가: CAPACITY_DEFAULT=300, cap/remain/usedPct 계산, OFFLINE일 때 막대 숨김