### PR TITLE
[20250913] 키오스크 탭 완료, 헤더 부분 수정 완료

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,8 +1,8 @@
 # 스프링부트 API (회원/JWT/포인트/세션 등)
-REACT_APP_API_URL=http://localhost:8080
+# REACT_APP_API_URL=http://localhost:8080
 
 # 아이패드 API (키오스크 화면)
-# REACT_APP_API_URL=http://192.168.10.72:8080
+REACT_APP_API_URL=http://192.168.10.72:8080
 
 # 라즈베리파이 API (컨베이어/AI 요청/결과)
 REACT_APP_PI_API_URL=http://192.168.10.245:5000

--- a/frontend/src/admin/components/AdminDashboard.js
+++ b/frontend/src/admin/components/AdminDashboard.js
@@ -45,6 +45,10 @@
  *   - 250912 | yukyeong | 대시보드 탭 진입 시 getKioskRuns 로드 추가(오늘 기준 수용량 계산용 로그)
  *   - 250912 | yukyeong | DashboardTab에 kioskRuns 전달
  *   - 250912 | sehui | 포인트 환급 요청 상태 변수와 함수 생성
+ *   - 250912 | yukyeong | DashboardTab에 kioskRuns 전달
+ *   - 250913 | yukyeong | 헤더 로고를 Link로 교체하여 클릭 시 "/"로 이동하도록 수정
+ *   - 250913 | yukyeong | jwtDecode로 토큰에서 role/phone 추출 로직 추가 및 예외 처리
+ *   - 250913 | yukyeong | 관리자명 옆에 마스킹 전화번호 표기(관리자 (010-****-1111)) 및 formatPhone 유틸 추가
  */
 
 import { getKiosks, getKioskRuns, updateKiosk, getTotal, updateKioskStatus } from '../../api/admin.js';
@@ -62,6 +66,17 @@ import KioskTab from '../pages/KioskTab.js';
 import NoticeTab from '../pages/NoticeTab.js';              // 새로 추가
 import '../styles/AdminDashboard.css'; // styles 폴더 위치 확인 필요
 import logo from '../img/logo.png';    // img 폴더 위치 확인 필요
+import { Link } from 'react-router-dom';
+import { jwtDecode } from 'jwt-decode';
+
+const formatPhone = (p) => {
+  const d = String(p ?? "").replace(/\D/g, "");
+  if (d.length < 10) return p ?? "";
+  // 010-****-1111 형태로 마스킹 + 하이픈
+  const mid = d.length === 11 ? d.slice(3, 7) : d.slice(3, 6);
+  const end = d.slice(-4);
+  return `010-${"*".repeat(mid.length)}-${end}`;
+};
 
 function AdminDashboard({ onNavigateToMain }) {
 
@@ -81,6 +96,23 @@ function AdminDashboard({ onNavigateToMain }) {
     // ========== 상태 관리 ==========
     const [currentTime, setCurrentTime] = useState('');
     const [activeTab, setActiveTab] = useState('dashboard');
+
+    const token = localStorage.getItem("accessToken");
+let role = null;
+let phone = null;
+
+if (token) {
+  try {
+    const decoded = jwtDecode(token);
+    role = decoded.role; // ADMIN, USER 등
+    phone = decoded.sub || decoded.phone || null; // 토큰에 저장된 필드명에 맞게 조정
+  } catch (e) {
+    console.error("⚠️ 토큰 디코딩 실패", e);
+  }
+}
+
+// 토큰 디코딩한 phone이 있다고 가정 (없으면 null)
+const phoneText = phone ? formatPhone(phone) : null;
 
     // 실시간 시간 업데이트 (헤더 우측 표시용)
     useEffect(() => {
@@ -330,8 +362,8 @@ function AdminDashboard({ onNavigateToMain }) {
     //포인트 환급 요청 필터링 함수
     const getFilteredRequests = () => {
         return selectedStatus === 'all'
-        ? refundRequests
-        : refundRequests.filter(request => request.requestStatus === selectedStatus)
+            ? refundRequests
+            : refundRequests.filter(request => request.requestStatus === selectedStatus)
     };
 
     // ========== 렌더링 ==========
@@ -343,7 +375,9 @@ function AdminDashboard({ onNavigateToMain }) {
                     {/* 왼쪽: 로고 */}
                     <div className="header-left">
                         <div className="logo">
-                            <img src={logo} alt="PETCoin 로고" className="logo-img" />
+                            <Link to="/">
+                                <img src={logo} alt="PETCoin 로고" className="logo-img" />
+                            </Link>
                         </div>
                     </div>
 
@@ -354,11 +388,13 @@ function AdminDashboard({ onNavigateToMain }) {
                                 👨‍💼
                             </div>
                             <div className="profile-info">
-                                <h1 className="profile-name">관리자</h1>
-                                <p className="profile-details">
-                                    시스템 관리 • {currentTime}
-                                </p>
-                            </div>
+  <h1 className="profile-name">
+    관리자 {phoneText && <span className="phone-text">({phoneText})</span>}
+  </h1>
+  <p className="profile-details">
+    시스템 관리 • {currentTime}
+  </p>
+</div>
                         </div>
                     </div>
                 </div>
@@ -441,6 +477,7 @@ function AdminDashboard({ onNavigateToMain }) {
                 {activeTab === 'kiosk' && (
                     <KioskTab
                         kioskData={kioskData}
+                        kioskRuns={kioskLogs} // 추가
                         selectedKiosk={selectedKiosk}
                         setSelectedKiosk={setSelectedKiosk}
                         selectedLogType={selectedLogType}

--- a/frontend/src/admin/pages/DashboardTab.js
+++ b/frontend/src/admin/pages/DashboardTab.js
@@ -33,7 +33,7 @@ const statusToCss = (s) => {
 
 function DashboardTab({ dashboardStats = {}, kioskData = [], kioskRuns = [] }) {
 
-    // ✅ 특정 키오스크의 "오늘" 병 합계 + 건수만 계산 (로컬 날짜 기준, KST 고려 X: 가장 단순)
+    // 특정 키오스크의 "오늘" 병 합계 + 건수만 계산 (로컬 날짜 기준, KST 고려 X: 가장 단순)
     const getTodayStats = (kiosk) => {
         const id = kiosk.recycleId ?? kiosk.kioskId ?? kiosk.id;
         const today = new Date();

--- a/frontend/src/admin/styles/AdminDashboard.css
+++ b/frontend/src/admin/styles/AdminDashboard.css
@@ -1868,8 +1868,7 @@
 
 /* 프로필 상세 정보 (등급, 연속 참여일 등) */
 .profile-details {
-    color: #94a3b8;
-    /* 연한 회색 */
+    color: #ffe9b0;
     font-size: 14px;
     font-weight: 400;
     margin: 0;

--- a/frontend/src/components/pages/MainPage.js
+++ b/frontend/src/components/pages/MainPage.js
@@ -144,7 +144,7 @@ const MainPage = () => {
                       <div className="screen-icon">♻️</div>
                     </div>
                     <div className="screen-text">페트병을 넣어주세요</div>
-                    <div className="screen-points">+50P 적립 예정</div>
+                    <div className="screen-points">+10P 적립 예정</div>
                   </div>
                 </div>
                 <div className="kiosk-slot">

--- a/frontend/src/components/styles/MainPage.css
+++ b/frontend/src/components/styles/MainPage.css
@@ -175,8 +175,8 @@
   margin: 0 auto;
   padding: 0 1.5rem;
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 4rem;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 5rem;
   align-items: center;
 }
 


### PR DESCRIPTION
<관리자 페이지 - 키오스크탭 키오스크 상태 관리 부분 수정>
KioskTab.js
- '오늘: N개 · N건' 표시(대시보드와 통일), 온도/습도/오류 제거
- 수용량을 '현재 기준(currentCount)'으로 표시 및 진행바 반영(OFFLINE 숨김)

AdminDashboard.js
- DashboardTab에 kioskRuns 전달

<수용량 계산 방법>
수용량 = 기본 최대치(cap) 300 - 오늘 투입량(bottles)
DB 실시간 값(`currentCount`)이 없으니까 "오늘 얼마나 넣었는지"를 기반으로 계산 중


<로그인 후 역할별로 다른 화면으로 이동>
1. 백엔드: 로그인 응답에 role 포함되었는지 확인하기
2. 리액트: 로그인 성공시 토큰 저장하는지 확인하기
3. 리액트: LoginPage.js
- JWT 역할 기반 라우팅 도입: jwt-decode import 및 routeByRole() 헬퍼 추가
- 로그인/자동가입 성공 시 토큰 저장→axios Authorization 주입→역할별 라우팅(ADMIN→/admin, 그외→/user) 적용
- 중복 네비게이션 방지: routeByRole 호출 후 return 처리, 토큰 미수신 시 에러 메시지 추가


<관리자 페이지 헤더 부분 로고 클릭 시 메인 이동, 관리자 권한 옆에 핸드폰 번호 표시>
- 헤더 로고를 Link로 교체하여 클릭 시 "/"로 이동하도록 수정
- jwtDecode로 토큰에서 role/phone 추출 로직 추가 및 예외 처리
- 관리자명 옆에 마스킹 전화번호 표기(관리자 (010-****-1111)) 및 formatPhone 유틸 추가


<마이페이지 헤더 부분 로고 클릭 시 메인 이동, 핸드폰 번호, 마스킹 표시>
- 헤더 UX 개선: 로고를 Link로 교체해 클릭 시 "/"로 이동
- 전화번호 표시 정책 적용: JWT/로컬스토리지/props 우선순위로 로드, normalizePhone/maskPhone 유틸 추가, 마스킹(010-****-1234) 후 헤더에 표시
- 하드코딩 사용자 정보(name/grade) 제거, userData를 최소 형태(아바타/포인트 등)로 축소
- 하위 탭 공통 props에 phoneNumber를 마스킹된 phoneDisplay로 전달하도록 변경


<메인페이지 레이아웃 깨짐 해결>
MainPage.css
hero-content grid 비율을 1.2fr/0.8fr + gap 5rem 으로 수정하여 텍스트 영역이 좁아지던 문제(키오스크 목업과 겹침 현상) 해결