### PR TITLE
[20250915] 키오스크 탭 로그 페이징 완료, 메인페이지 완료

### DIFF
--- a/backend/petcoin/src/main/java/com/petcoin/service/KioskRunServiceImpl.java
+++ b/backend/petcoin/src/main/java/com/petcoin/service/KioskRunServiceImpl.java
@@ -44,6 +44,7 @@ import java.util.List;
  *   - 250904 | sehui | 실행 세션 목록 조회 (페이징 + 조건) 메서드 추가
  *   - 250904 | sehui | 실행 세션 총 개수 조회 메서드 추가
  *   - 250905 | yukyeong | 취소 로직에서 PointHistory 조회/적립 제거 → 순수 상태 전이(RUNNING→CANCELLED)만 수행
+ *   - 250915 | yukyeong | getTotalRunCount에서 0건을 정상 처리(예외 제거), 오류 시 0으로 폴백
  */
 
 @Service
@@ -204,12 +205,11 @@ public class KioskRunServiceImpl implements KioskRunService{
     @Override
     public int getTotalRunCount(KioskRunCriteria cri) {
 
-        int totalRunCount = kioskRunMapper.getTotalRunCount(cri);
-
-        if(totalRunCount == 0) {
-            throw new IllegalArgumentException("실행 세션 총 개수 조회 오류 발생");
+        try {
+            return kioskRunMapper.getTotalRunCount(cri);
+        } catch (Exception e) {
+            log.error("실행 세션 총 개수 조회 실패", e);
+            return 0; // 예외가 나도 0으로 폴백
         }
-
-        return totalRunCount;
     }
 }

--- a/backend/petcoin/src/main/resources/mapper/KioskRunMapper.xml
+++ b/backend/petcoin/src/main/resources/mapper/KioskRunMapper.xml
@@ -29,6 +29,8 @@
  *   - 250905 | sehui | 대시보드용 총 수거량 조회 추가
  *   - 250905 | yukyeong | cancelRun 쿼리 단순화: status='CANCELLED', ended_at=현재시간만 업데이트 (포인트/총수량 연산 제거)
  *   - 250909 | yukyeong | SQL 별칭 정합성: kioskRunWhere와 목록/카운트 쿼리에 kr. 접두사 적용, ORDER BY를 kr.started_at로 수정
+ *   - 250915 | yukyeong | status='' 입력 시 조건 제외하도록 보강 (쿼리 안정성)
+ *   - 250915 | yukyeong | kioskRunWhere 조건 보강 수정: status != '' 제거 → Enum 비교 오류(취소/완료 조회 시 500) 해결
 -->
 
 

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,8 +1,8 @@
 # 스프링부트 API (회원/JWT/포인트/세션 등)
-# REACT_APP_API_URL=http://localhost:8080
+REACT_APP_API_URL=http://localhost:8080
 
 # 아이패드 API (키오스크 화면)
-REACT_APP_API_URL=http://192.168.10.72:8080
+# REACT_APP_API_URL=http://192.168.10.72:8080
 
 # 라즈베리파이 API (컨베이어/AI 요청/결과)
 REACT_APP_PI_API_URL=http://192.168.10.245:5000

--- a/frontend/src/admin/components/AdminDashboard.js
+++ b/frontend/src/admin/components/AdminDashboard.js
@@ -49,6 +49,11 @@
  *   - 250913 | yukyeong | 헤더 로고를 Link로 교체하여 클릭 시 "/"로 이동하도록 수정
  *   - 250913 | yukyeong | jwtDecode로 토큰에서 role/phone 추출 로직 추가 및 예외 처리
  *   - 250913 | yukyeong | 관리자명 옆에 마스킹 전화번호 표기(관리자 (010-****-1111)) 및 formatPhone 유틸 추가
+ *   - 250915 | yukyeong | 탭별 선택 상태 분리: selectedRecycleId(수거내역)·selectedKioskId(키오스크) 추가
+ *   - 250915 | yukyeong | 키오스크 로그 로딩 시 kioskId 숫자 변환 및 'all'일 때 파라미터 제외 처리
+ *   - 250915 | yukyeong | getFilteredKioskData/getFilteredRecycleStats 함수 분리 및 props 전달 대상 교정
+ *   - 250915 | yukyeong | 로그 응답 안전 폴백(list ?? [] / 실패 시 [])
+ *   - 250915 | yukyeong | 키오스크 로그 페이징 도입: selectedPage/kioskRunPageInfo 상태 추가, getKioskRuns 호출에 pageNum/amount 반영, KioskTab에 pageInfo·setSelectedPage 전달
  */
 
 import { getKiosks, getKioskRuns, updateKiosk, getTotal, updateKioskStatus } from '../../api/admin.js';
@@ -70,12 +75,12 @@ import { Link } from 'react-router-dom';
 import { jwtDecode } from 'jwt-decode';
 
 const formatPhone = (p) => {
-  const d = String(p ?? "").replace(/\D/g, "");
-  if (d.length < 10) return p ?? "";
-  // 010-****-1111 형태로 마스킹 + 하이픈
-  const mid = d.length === 11 ? d.slice(3, 7) : d.slice(3, 6);
-  const end = d.slice(-4);
-  return `010-${"*".repeat(mid.length)}-${end}`;
+    const d = String(p ?? "").replace(/\D/g, "");
+    if (d.length < 10) return p ?? "";
+    // 010-****-1111 형태로 마스킹 + 하이픈
+    const mid = d.length === 11 ? d.slice(3, 7) : d.slice(3, 6);
+    const end = d.slice(-4);
+    return `010-${"*".repeat(mid.length)}-${end}`;
 };
 
 function AdminDashboard({ onNavigateToMain }) {
@@ -83,7 +88,8 @@ function AdminDashboard({ onNavigateToMain }) {
     // 하드코딩 삭제하고 빈 배열로 시작
     const [kioskData, setKioskData] = useState([]); // 키오스크 데이터 (REQ-002)
     const [kioskLogs, setKioskLogs] = useState([]); // 키오스크 로그 데이터 (REQ-006)
-    const [selectedKiosk, setSelectedKiosk] = useState('all'); // 현재 선택된 키오스크 ID (드롭다운) - 기본은 'all' (전체 보기)
+    const [selectedRecycleId, setSelectedRecycleId] = useState('all'); // 수거내역 탭 전용 선택 상태
+    const [selectedKioskId, setSelectedKioskId] = useState('all'); // 키오스크 탭 전용 선택 상태
     const [selectedLogType, setSelectedLogType] = useState('all'); // 현재 선택된 로그 유형 (드롭다운) - 기본은 'all' (전체 보기)
     const [memberData, setMemberData] = useState([]);   //회원 관리 데이터 (REQ-003)
     const [refundRequests, setRefundRequests] = useState([]);       //포인트 환급 요청 데이터 (REQ-004, REQ-005)
@@ -91,28 +97,29 @@ function AdminDashboard({ onNavigateToMain }) {
     const [pageInfo, setPageInfo] = useState([]);       //페이지 정보
     const [recycleStats, setRecycleStats] = useState([]);
     const [selectedStatus, setSelectedStatus] = useState('all');        //포인트 환급 요청 상태
-
+    const [kioskRunPageInfo, setKioskRunPageInfo] = useState({});
+    const [selectedPage, setSelectedPage] = useState(1);
 
     // ========== 상태 관리 ==========
     const [currentTime, setCurrentTime] = useState('');
     const [activeTab, setActiveTab] = useState('dashboard');
 
     const token = localStorage.getItem("accessToken");
-let role = null;
-let phone = null;
+    let role = null;
+    let phone = null;
 
-if (token) {
-  try {
-    const decoded = jwtDecode(token);
-    role = decoded.role; // ADMIN, USER 등
-    phone = decoded.sub || decoded.phone || null; // 토큰에 저장된 필드명에 맞게 조정
-  } catch (e) {
-    console.error("⚠️ 토큰 디코딩 실패", e);
-  }
-}
+    if (token) {
+        try {
+            const decoded = jwtDecode(token);
+            role = decoded.role; // ADMIN, USER 등
+            phone = decoded.sub || decoded.phone || null; // 토큰에 저장된 필드명에 맞게 조정
+        } catch (e) {
+            console.error("⚠️ 토큰 디코딩 실패", e);
+        }
+    }
 
-// 토큰 디코딩한 phone이 있다고 가정 (없으면 null)
-const phoneText = phone ? formatPhone(phone) : null;
+    // 토큰 디코딩한 phone이 있다고 가정 (없으면 null)
+    const phoneText = phone ? formatPhone(phone) : null;
 
     // 실시간 시간 업데이트 (헤더 우측 표시용)
     useEffect(() => {
@@ -157,25 +164,30 @@ const phoneText = phone ? formatPhone(phone) : null;
         let alive = true;
         // selectedKiosk가 'all'이면 쿼리에서 제외(=undefined)해서 불필요한 "status=null" 전송 방지
         const params = {
-            pageNum: 1,
-            amount: 50,
-            ...(selectedKiosk === 'all' ? {} : { kioskId: selectedKiosk }),
+            pageNum: selectedPage,
+            amount: 20,
+            ...(selectedKioskId === 'all' ? {} : { kioskId: Number(selectedKioskId) }),
             ...(selectedLogType === 'all' ? {} : { status: selectedLogType }),
         };
 
         (async () => {
             try {
-                const { list /*, pageInfo*/ } = await getKioskRuns(params);
-                if (alive) setKioskLogs(list);
-                // pageInfo 필요해지면 setKioskRunPageInfo(pageInfo) 추가
+                const { list, pageInfo } = await getKioskRuns(params);
+                if (alive) {
+                    setKioskLogs(list ?? []);
+                    setKioskRunPageInfo(pageInfo ?? {}); // pageInfo도 저장
+                }
             } catch (e) {
                 console.error('키오스크 로그 로딩 실패', e);
-                if (alive) setKioskLogs([]);
+                if (alive) {
+                    setKioskLogs([]);
+                    setPageInfo({}); // 실패 시 빈 객체
+                }
             }
         })();
 
         return () => { alive = false; };
-    }, [activeTab, selectedKiosk, selectedLogType]);
+    }, [activeTab, selectedKioskId, selectedLogType, selectedPage]);
 
     //전체 회원 목록 조회
     useEffect(() => {
@@ -335,9 +347,9 @@ const phoneText = phone ? formatPhone(phone) : null;
 
     // ========== 필터링 함수들 ==========
     const getFilteredKioskData = () => {
-        return selectedKiosk === 'all'
+        return selectedKioskId === 'all'
             ? kioskData
-            : kioskData.filter(kiosk => kiosk.kioskId === selectedKiosk);
+            : kioskData.filter(kiosk => kiosk.kioskId === Number(selectedKioskId));
     };
 
     const getFilteredLogs = () => {
@@ -354,9 +366,9 @@ const phoneText = phone ? formatPhone(phone) : null;
     };
 
     const getFilteredRecycleStats = () => {
-        return selectedKiosk === 'all'
+        return selectedRecycleId === 'all'
             ? recycleStats
-            : recycleStats.filter(kiosk => kiosk.recycleId === Number(selectedKiosk));
+            : recycleStats.filter(kiosk => kiosk.recycleId === Number(selectedRecycleId));
     };
 
     //포인트 환급 요청 필터링 함수
@@ -388,13 +400,13 @@ const phoneText = phone ? formatPhone(phone) : null;
                                 👨‍💼
                             </div>
                             <div className="profile-info">
-  <h1 className="profile-name">
-    관리자 {phoneText && <span className="phone-text">({phoneText})</span>}
-  </h1>
-  <p className="profile-details">
-    시스템 관리 • {currentTime}
-  </p>
-</div>
+                                <h1 className="profile-name">
+                                    관리자 {phoneText && <span className="phone-text">({phoneText})</span>}
+                                </h1>
+                                <p className="profile-details">
+                                    시스템 관리 • {currentTime}
+                                </p>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -450,8 +462,8 @@ const phoneText = phone ? formatPhone(phone) : null;
                 {activeTab === 'collection' && (
                     <CollectionHistoryTab
                         kioskData={recycleStats}
-                        selectedKiosk={selectedKiosk}
-                        setSelectedKiosk={setSelectedKiosk}
+                        selectedRecycleId={selectedRecycleId}
+                        setSelectedRecycleId={setSelectedRecycleId}
                         getFilteredKioskData={getFilteredRecycleStats}
                     />
                 )}
@@ -478,13 +490,15 @@ const phoneText = phone ? formatPhone(phone) : null;
                     <KioskTab
                         kioskData={kioskData}
                         kioskRuns={kioskLogs} // 추가
-                        selectedKiosk={selectedKiosk}
-                        setSelectedKiosk={setSelectedKiosk}
+                        selectedKiosk={selectedKioskId}
+                        setSelectedKiosk={setSelectedKioskId}
                         selectedLogType={selectedLogType}
                         setSelectedLogType={setSelectedLogType}
                         getFilteredKioskData={getFilteredKioskData}
                         getFilteredLogs={getFilteredLogs}
                         handleKioskStatusChange={handleKioskStatusChange}
+                        pageInfo={kioskRunPageInfo}
+                        setSelectedPage={setSelectedPage}
                     />
                 )}
             </main>

--- a/frontend/src/admin/pages/CollectionHistoryTab.js
+++ b/frontend/src/admin/pages/CollectionHistoryTab.js
@@ -18,6 +18,9 @@
  *   - 250911 | yukyeong | 경과 시간 계산 로직 추가 (분/시간/일 단위 표시)
  *   - 250911 | yukyeong | todayCollection, capacity, 센서 데이터(온도/습도/오류) 섹션 주석 처리
  *   - 250911 | yukyeong | ONLINE/MAINT 상태를 뱃지(`status-badge`) 스타일로 표시하도록 수정
+ *   - 250913 | yukyeong | 리스트 key를 name 대신 recycleId로 사용하여 경고 제거, OFFLINE 상태를 inactive로 매핑해 UI 표시 개선
+ *   - 250915 | yukyeong | props를 selectedRecycleId/setSelectedRecycleId로 교체
+ *   - 250915 | yukyeong | 카드 key 안전 처리(recycleId → kioskId → name 순서)
  */
 
 import React from 'react';
@@ -25,17 +28,18 @@ import React from 'react';
 const statusToCss = (s) => {
     if (s === 'ONLINE') return 'active';
     if (s === 'MAINT') return 'maintenance';
+    if (s === 'OFFLINE') return 'inactive';
     return 'unknown';
 };
 
-function CollectionHistoryTab({ kioskData, selectedKiosk, setSelectedKiosk, getFilteredKioskData }) {
+function CollectionHistoryTab({ kioskData, selectedRecycleId, setSelectedRecycleId, getFilteredKioskData }) {
     return (
         <div className="collection-section">
             <div className="collection-header">
                 <h2>수거 내역</h2>
                 <select
-                    value={selectedKiosk}
-                    onChange={(e) => setSelectedKiosk(e.target.value)}
+                    value={selectedRecycleId}
+                    onChange={(e) => setSelectedRecycleId(e.target.value)}
                     className="kiosk-select"
                 >
                     <option value="all">전체 수거함</option>
@@ -49,13 +53,13 @@ function CollectionHistoryTab({ kioskData, selectedKiosk, setSelectedKiosk, getF
 
             <div className="collection-stats">
                 {getFilteredKioskData().map(kiosk => (
-                    <div key={kiosk.name} className="collection-card">
+                    <div key={kiosk.recycleId ?? kiosk.kioskId ?? kiosk.name} className="collection-card">
                         <div className="collection-card-header">
                             <h3>📍 {kiosk.recycleName ?? kiosk.name}</h3>
                             <span className={`status-badge ${statusToCss(kiosk.status)}`}>
                                 {kiosk.status === 'ONLINE' ? '운영중' 
                                     : kiosk.status === 'MAINT' ? '점검중' 
-                                    : '알수없음'}
+                                    : kiosk.status === 'OFFLINE' ? '미운영'  : '알수없음'}
                             </span>
                         </div>
 

--- a/frontend/src/admin/pages/KioskTab.js
+++ b/frontend/src/admin/pages/KioskTab.js
@@ -43,6 +43,7 @@
  *   - 250911 | yukyeong | 미운영 상태 도입: 드롭다운에 OFFLINE(미운영) 옵션 추가, statusToCss에 OFFLINE→'inactive' 매핑
  *   - 250913 | yukyeong | '오늘: N개 · N건' 표시(대시보드와 통일), 온도/습도/오류 제거
  *   - 250913 | yukyeong | 수용량을 '현재 기준(currentCount)'으로 표시 및 진행바 반영(OFFLINE 숨김)
+ *   - 250915 | yukyeong | 로그 페이징 UI 추가(log-pagination): 서버 pageInfo 기반 이전/번호/다음 버튼 렌더링, 필터 변경 시 페이지 1로 리셋(setSelectedPage(1)) 처리
  * 
  */
 
@@ -88,6 +89,8 @@ const detailsText = (log) => {
     }
 };
 
+
+
 function KioskTab({
     kioskData, // 전체 키오스크 목록
     kioskRuns, // 추가
@@ -97,7 +100,10 @@ function KioskTab({
     setSelectedLogType, // 로그 상태 변경 함수
     getFilteredKioskData, // 선택된 조건에 맞는 키오스크 목록 반환 함수
     getFilteredLogs, // 선택된 조건에 맞는 로그 목록 반환 함수
-    handleKioskStatusChange // 키오스크 상태 변경 처리 함수
+    handleKioskStatusChange, // 키오스크 상태 변경 처리 함수
+    pageInfo, // 추가
+    selectedPage, 
+    setSelectedPage // 추가
 }) {
     const getTodayStats = (kiosk) => {
         const id = kiosk.recycleId ?? kiosk.kioskId ?? kiosk.id;
@@ -129,7 +135,10 @@ function KioskTab({
                 <h2>키오스크 관리</h2>
                 <select
                     value={selectedKiosk}
-                    onChange={(e) => setSelectedKiosk(e.target.value === 'all' ? 'all' : Number(e.target.value))}  // all이면 문자열, 아니면 숫자 변환
+                    onChange={(e) => {
+                        setSelectedKiosk(e.target.value === 'all' ? 'all' : Number(e.target.value));
+                        setSelectedPage(1);   // 👈 추가
+                    }}
                     className="kiosk-select"
                 >
                     {/* 전체 선택 */}
@@ -195,7 +204,7 @@ function KioskTab({
                                         </span>
                                     </div>
 
-                                    
+
 
                                     {/* 진행바 (OFFLINE 숨김) */}
                                     {!isInactive && (
@@ -227,7 +236,11 @@ function KioskTab({
                         <select
                             className="log-type-filter"
                             value={selectedLogType}
-                            onChange={(e) => setSelectedLogType(e.target.value)}
+                            onChange={(e) => {
+                                setSelectedLogType(e.target.value);
+                                setSelectedPage(1);   // 👈 추가
+                            }}
+
                         >
                             <option value="all">전체</option>
                             <option value="RUNNING">실행중</option>
@@ -301,6 +314,46 @@ function KioskTab({
                         )}
                     </div>
                 </div>
+
+                {/* 로그 페이징 영역 */}
+                {pageInfo && (
+                    <div className="log-pagination">
+                        {/* 이전 버튼 */}
+                        {pageInfo.prev && (
+                            <button
+                                onClick={() => setSelectedPage(pageInfo.startPage - 1)}
+                                disabled={!pageInfo.prev}
+                            >
+                                이전
+                            </button>
+                        )}
+
+                        {/* 페이지 번호 */}
+                        {Array.from(
+                            { length: pageInfo.endPage - pageInfo.startPage + 1 },
+                            (_, i) => pageInfo.startPage + i
+                        ).map(page => (
+                            <button
+                                key={page}
+                                onClick={() => setSelectedPage(page)}
+                                className={page === selectedPage ? "log-active" : ""}
+                            >
+                                {page}
+                            </button>
+                        ))}
+
+                        {/* 다음 버튼 */}
+                        {pageInfo.next && (
+                            <button
+                                onClick={() => setSelectedPage(pageInfo.endPage + 1)}
+                                disabled={!pageInfo.next}
+                            >
+                                다음
+                            </button>
+                        )}
+                    </div>
+                )}
+
             </div>
         </div>
     );

--- a/frontend/src/admin/styles/AdminDashboard.css
+++ b/frontend/src/admin/styles/AdminDashboard.css
@@ -2845,3 +2845,70 @@
         break-inside: avoid;
     }
 }
+
+/* ===========================
+   Kiosk Logs Pagination (전용)
+   =========================== */
+.log-pagination {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
+  margin: 16px 0 8px;
+  flex-wrap: wrap;
+}
+
+/* 공통 버튼 베이스 */
+.log-pagination button {
+  appearance: none;
+  border: 1px solid #e2e8f0;         /* slate-200 */
+  background: #ffffff;
+  color: #0f172a;                    /* slate-900 */
+  padding: 8px 12px;
+  min-width: 36px;
+  border-radius: 10px;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  transition: box-shadow .15s ease, transform .02s ease, background .15s ease;
+}
+
+/* 호버 */
+.log-pagination button:hover:not(:disabled) {
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+}
+
+/* 활성 페이지 */
+.log-pagination .log-active {
+  background: #1d4ed8;              /* blue-700 */
+  color: #ffffff;
+  border-color: #1d4ed8;
+}
+
+/* 비활성(이전/다음 불가) */
+.log-pagination button:disabled {
+  cursor: not-allowed;
+  opacity: .5;
+  box-shadow: none;
+}
+
+/* 이전/다음 텍스트 버튼 강조(선택사항) */
+.log-pagination .log-prev,
+.log-pagination .log-next {
+  font-weight: 600;
+  padding: 8px 14px;
+}
+
+/* 모바일 대응 */
+@media (max-width: 480px) {
+  .log-pagination {
+    gap: 6px;
+    margin: 12px 0 6px;
+  }
+  .log-pagination button {
+    padding: 7px 10px;
+    min-width: 32px;
+    font-size: 13px;
+    border-radius: 8px;
+  }
+}

--- a/frontend/src/components/pages/MainPage.js
+++ b/frontend/src/components/pages/MainPage.js
@@ -15,6 +15,9 @@
  * @history
  * - 250902 | yukyeong | 라우팅 리팩토링: props.navigateTo 제거 → react-router-dom useNavigate() 도입
  * - 250910 | heekyung | 기존 페이지 내용 유지 및 검색 기능 추가
+ * - 250915 | heekyung | How it works: 기존 CSS 전량 교체(화살표 제거, 숫자 배지 좌상단 이동, 카드/호버/간격 리디자인)
+ * - 250915 | heekyung | Map: 지도 래퍼(.map-visual) 추가로 카드화 + 우측 리스트 제목/필터 레이아웃/알약 사이즈 조정
+ * - 250915 | heekyung | Benefits: 카드화(라운드/보더/섀도), 진입/호버 효과 추가, 설명 \n + pre-line로 강제 줄바꿈
  */
 
 import React, { useEffect, useState } from 'react';
@@ -75,7 +78,7 @@ const MainPage = () => {
   const handleSearch = () => {
     const { sido, sigungu, dong } = searchParams;
     const query = `sido=${sido}&sigungu=${sigungu}&dong=${dong}`;
-    
+
     api.get(`/api/locations?${query}`)
       .then(response => {
         setKioskLocations(response.data);
@@ -85,12 +88,20 @@ const MainPage = () => {
       });
   };
 
-  const benefits = [
-    { icon: '⚡', title: '즉시 포인트 적립', description: '페트병을 넣는 순간 바로 포인트가 적립되어 실시간으로 확인 가능합니다', gradient: 'from-yellow-400 to-orange-500' },
-    { icon: '💳', title: '현금 전환 가능', description: '적립된 포인트를 언제든지 현금으로 출금하여 바로 사용할 수 있습니다', gradient: 'from-green-400 to-blue-500' },
-    { icon: '🌍', title: '지구 환경 보호', description: '재활용을 통해 환경을 보호하고 지속가능한 미래를 함께 만들어갑니다', gradient: 'from-green-400 to-green-600' },
-    { icon: '🎯', title: '간편한 이용', description: '복잡한 절차 없이 페트병만 넣으면 끝! 누구나 쉽게 이용 가능합니다', gradient: 'from-purple-400 to-pink-500' }
-  ];
+const benefits = [
+  { icon: '⚡', title: '즉시 포인트 적립',
+    description: '페트병을 넣는 순간 바로 포인트가 적립되어\n실시간으로 확인 가능합니다',
+    gradient: 'from-yellow-400 to-orange-500' },
+  { icon: '💳', title: '현금 전환 가능',
+    description: '적립된 포인트를 언제든지 현금으로 출금하여\n바로 사용할 수 있습니다',
+    gradient: 'from-green-400 to-blue-500' },
+  { icon: '🌍', title: '지구 환경 보호',
+    description: '재활용을 통해 환경을 보호하고\n지속가능한 미래를 함께 만들어갑니다',
+    gradient: 'from-green-400 to-green-600' },
+  { icon: '🎯', title: '간편한 이용',
+    description: '복잡한 절차 없이 페트병만 넣으면 끝!\n누구나 쉽게 이용 가능합니다',
+    gradient: 'from-purple-400 to-pink-500' }
+];
 
   return (
     <div className="main-page">
@@ -103,7 +114,7 @@ const MainPage = () => {
             <div className="shape shape-3">💚</div>
           </div>
         </div>
-        
+
         <div className="hero-content">
           <div className="hero-text">
             <div className="hero-badge">
@@ -120,7 +131,7 @@ const MainPage = () => {
             <div className="hero-buttons">
               <button
                 className="btn-primary glow"
-                onClick={() => navigate('/signup')}
+                onClick={() => navigate('/login')}
               >
                 <span>지금 시작하기</span>
                 <div className="btn-shine"></div>
@@ -133,7 +144,7 @@ const MainPage = () => {
               </button>
             </div>
           </div>
-          
+
           <div className="hero-visual">
             <div className="main-kiosk-container">
               <div className="kiosk-mockup">
@@ -187,7 +198,7 @@ const MainPage = () => {
                 {index < 3 && (
                   <div className="step-connector">
                     <div className="connector-line"></div>
-                    <div className="connector-arrow">→</div>
+                    <div className="connector-arrow" />
                   </div>
                 )}
               </div>
@@ -207,33 +218,58 @@ const MainPage = () => {
           <div className="map-container">
             {/* 지도 */}
             <div className="map-visual">
-              <KioskMap locations={kioskLocations} /> 
+              <KioskMap locations={kioskLocations} />
             </div>
 
             {/* 검색 + 결과 리스트 */}
             <div className="location-list">
+              {/* ① 헤더는 타이틀만 */}
               <div className="location-header">
                 <h3 className="location-title">주변 키오스크</h3>
-                <div className="search-container">
-                  <select value={searchParams.sido} onChange={e => setSearchParams({ ...searchParams, sido: e.target.value })}>
-                    <option value="">시 선택</option>
-                    {sidoList.map((sido, idx) => <option key={idx} value={sido}>{sido}</option>)}
-                  </select>
-
-                  <select value={searchParams.sigungu} onChange={e => setSearchParams({ ...searchParams, sigungu: e.target.value })}>
-                    <option value="">구 선택</option>
-                    {sigunguList.map((sigungu, idx) => <option key={idx} value={sigungu}>{sigungu}</option>)}
-                  </select>
-
-                  <select value={searchParams.dong} onChange={e => setSearchParams({ ...searchParams, dong: e.target.value })}>
-                    <option value="">동 선택</option>
-                    {dongList.map((dong, idx) => <option key={idx} value={dong}>{dong}</option>)}
-                  </select>
-
-                  <button onClick={handleSearch}>검색</button>
-                </div>
               </div>
 
+              {/* ② 제목 아래 전용 행(그리드) */}
+              <form
+                className="location-filters wide"
+                onSubmit={(e) => { e.preventDefault(); handleSearch(); }}
+              >
+                <select
+                  className="ui-select"
+                  value={searchParams.sido}
+                  onChange={e => setSearchParams({ ...searchParams, sido: e.target.value })}
+                >
+                  <option value="">시 선택</option>
+                  {sidoList.map((sido, idx) => (
+                    <option key={idx} value={sido}>{sido}</option>
+                  ))}
+                </select>
+
+                <select
+                  className="ui-select"
+                  value={searchParams.sigungu}
+                  onChange={e => setSearchParams({ ...searchParams, sigungu: e.target.value })}
+                >
+                  <option value="">구 선택</option>
+                  {sigunguList.map((sigungu, idx) => (
+                    <option key={idx} value={sigungu}>{sigungu}</option>
+                  ))}
+                </select>
+
+                <select
+                  className="ui-select"
+                  value={searchParams.dong}
+                  onChange={e => setSearchParams({ ...searchParams, dong: e.target.value })}
+                >
+                  <option value="">동 선택</option>
+                  {dongList.map((dong, idx) => (
+                    <option key={idx} value={dong}>{dong}</option>
+                  ))}
+                </select>
+
+                <button className="ui-btn primary" type="submit">검색</button>
+              </form>
+
+              {/* 리스트 */}
               {kioskLocations.length > 0 ? (
                 kioskLocations.map((location, index) => (
                   <div key={index} className="location-item">
@@ -259,7 +295,7 @@ const MainPage = () => {
             <h2 className="section-title">PETCOIN의 특별한 장점</h2>
             <p className="section-subtitle">왜 PETCOIN를 선택해야 할까요?</p>
           </div>
-        <div className="benefits-grid">
+          <div className="benefits-grid">
             {benefits.map((benefit, index) => (
               <div key={index} className="benefit-card" style={{ '--delay': `${index * 0.1}s` }}>
                 <div className={`benefit-gradient bg-gradient-to-br ${benefit.gradient}`}></div>
@@ -289,7 +325,7 @@ const MainPage = () => {
             <div className="cta-buttons">
               <button
                 className="btn-primary large glow"
-                onClick={() => navigate('/signup')}
+                onClick={() => navigate('/login')}
               >
                 <span>무료 회원가입</span>
                 <div className="btn-shine"></div>

--- a/frontend/src/components/styles/MainPage.css
+++ b/frontend/src/components/styles/MainPage.css
@@ -120,7 +120,8 @@
   align-items: center;
   background: linear-gradient(135deg, #fff7ed 0%, #ffedd5 25%, #fed7aa 50%, #fdba74 75%, #fb923c 100%);
   overflow: hidden;
-  padding-top: 0; /* Header height compensation */
+  padding-top: 0;
+  /* Header height compensation */
 }
 
 .hero-background {
@@ -164,8 +165,15 @@
 }
 
 @keyframes float {
-  0%, 100% { transform: translateY(0px) rotate(0deg); }
-  50% { transform: translateY(-20px) rotate(10deg); }
+
+  0%,
+  100% {
+    transform: translateY(0px) rotate(0deg);
+  }
+
+  50% {
+    transform: translateY(-20px) rotate(10deg);
+  }
 }
 
 .hero-content {
@@ -194,9 +202,22 @@
 }
 
 @keyframes bounce {
-  0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
-  40% { transform: translateY(-10px); }
-  60% { transform: translateY(-5px); }
+
+  0%,
+  20%,
+  50%,
+  80%,
+  100% {
+    transform: translateY(0);
+  }
+
+  40% {
+    transform: translateY(-10px);
+  }
+
+  60% {
+    transform: translateY(-5px);
+  }
 }
 
 .hero-title {
@@ -229,8 +250,13 @@
 }
 
 @keyframes glow {
-  from { box-shadow: 0 0 5px var(--primary-orange); }
-  to { box-shadow: 0 0 20px var(--primary-orange), 0 0 30px var(--primary-orange); }
+  from {
+    box-shadow: 0 0 5px var(--primary-orange);
+  }
+
+  to {
+    box-shadow: 0 0 20px var(--primary-orange), 0 0 30px var(--primary-orange);
+  }
 }
 
 .hero-description {
@@ -283,8 +309,14 @@
 }
 
 @keyframes shine {
-  0% { left: -100%; }
-  50%, 100% { left: 100%; }
+  0% {
+    left: -100%;
+  }
+
+  50%,
+  100% {
+    left: 100%;
+  }
 }
 
 .btn-secondary {
@@ -316,7 +348,8 @@
   box-shadow: var(--shadow-medium);
 }
 
-.btn-primary.large, .btn-secondary.large {
+.btn-primary.large,
+.btn-secondary.large {
   padding: 1.4rem 3rem;
   font-size: 1.2rem;
   line-height: 1.4;
@@ -396,8 +429,13 @@
 }
 
 @keyframes rotate {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .screen-text {
@@ -463,81 +501,122 @@
 }
 
 @keyframes floatBottle {
-  0%, 100% { transform: translateY(0px) rotate(0deg); opacity: 0.7; }
-  50% { transform: translateY(-30px) rotate(15deg); opacity: 1; }
+
+  0%,
+  100% {
+    transform: translateY(0px) rotate(0deg);
+    opacity: 0.7;
+  }
+
+  50% {
+    transform: translateY(-30px) rotate(15deg);
+    opacity: 1;
+  }
 }
 
 /* Section Headers */
 .section-header {
   text-align: center;
-  margin-bottom: 4rem;
+  margin-bottom: clamp(48px, 6vw, 96px); /* 원래 32~72px → 48~96px 정도로 확대 */
 }
 
+/* 공통 */
 .section-title {
+  position: relative;
   font-size: 3rem;
   font-weight: 800;
   color: var(--text-dark);
   margin-bottom: 1rem;
-  position: relative;
+
+  /* 밑줄 기본값 */
+  --bar-w: 96px;
+  /* 길이 */
+  --bar-h: 4px;
+  /* 두께 */
+  --bar-left: 50%;
+  /* 시작 위치 */
+  --bar-tx: -50%;
+  /* X 보정 */
+  --bar-opacity: 1;
+  /* 투명도 */
 }
 
+/* 1) 기존 제목 밑줄 제거 */
 .section-title::after {
-  content: '';
-  position: absolute;
-  bottom: -10px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 80px;
-  height: 4px;
-  background: linear-gradient(45deg, var(--primary-orange), var(--primary-orange-light));
-  border-radius: 2px;
+  content: none !important;
 }
+
 
 .section-subtitle {
   font-size: 1.2rem;
   color: var(--text-gray);
 }
 
-/* How it works Section */
+/* =========================
+   HOW IT WORKS — CLEAN RESET
+   ========================= */
 .how-it-works {
-  padding: 6rem 0;
-  background: white;
+  --hiw-card-w: 240px;
+  /* 카드 가로 */
+  --hiw-card-h: 340px;
+  /* 카드 최소 높이 */
+  --hiw-gap: 56px;
+  /* 카드 간격 */
+  --hiw-conn-w: 88px;
+  /* 커넥터 너비 */
+  margin-bottom: clamp(48px, 8vw, 120px);
+  margin-top: clamp(48px, 8vw, 120px);
 }
 
-.steps-container {
+.how-it-works .section-title {
+  --bar-w: 100%;
+  --bar-h: 3px;
+}
+
+/* 행 레이아웃 */
+.how-it-works .steps-container {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: center;
+  gap: var(--hiw-gap);
+  flex-wrap: nowrap;
 }
 
-.step-wrapper {
+/* 카드 컨테이너(늘어나지 않게) */
+.how-it-works .step-wrapper {
+  flex: 0 0 auto;
   display: flex;
-  align-items: center;
-  flex: 1;
-  min-width: 250px;
+  justify-content: center;
 }
 
-.step-card {
-  background: white;
-  border: 2px solid var(--border-light);
-  border-radius: 2rem;
-  padding: 2.5rem 2rem;
-  text-align: center;
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+/* 카드: 폭/높이 통일 + 배지 안잘리게 */
+.how-it-works .step-card {
   position: relative;
-  overflow: hidden;
-  width: 100%;
+  width: var(--hiw-card-w);
+  min-height: var(--hiw-card-h);
+  overflow: visible;
+  /* << 숫자 배지 안 잘림 */
+  background: #fff;
+  border: 2px solid var(--border-light);
+  border-radius: 24px;
+  padding: 36px 24px;
+  text-align: center;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  transition: .25s ease;
 }
 
-.step-card:hover {
-  transform: translateY(-10px);
-  border-color: var(--primary-orange);
-  box-shadow: 0 20px 40px rgba(249, 115, 22, 0.2);
+.how-it-works .step-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-medium, 0 10px 20px rgba(0, 0, 0, .08));
+  border-color: rgba(249, 115, 22, .35);
 }
 
-.step-icon-bg {
+/* 아이콘 배경 */
+.how-it-works .step-icon-bg {
   width: 80px;
   height: 80px;
   background: linear-gradient(45deg, var(--primary-orange), var(--primary-orange-light));
@@ -549,72 +628,168 @@
   box-shadow: 0 10px 20px rgba(249, 115, 22, 0.3);
 }
 
-.step-icon {
+.how-it-works .step-icon {
   font-size: 2.5rem;
+  color: #fff;
 }
 
-.step-number {
+/* 숫자 배지 */
+.how-it-works .step-number {
   position: absolute;
-  top: -15px;
-  right: -15px;
+  top: -14px;
+  right: auto;
+  left: -14px;
   width: 40px;
   height: 40px;
-  background: linear-gradient(45deg, #ef4444, #dc2626);
-  color: white;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 700;
-  font-size: 1.2rem;
-  box-shadow: var(--shadow-medium);
+  font-weight: 800;
+  font-size: 14px;
+  color: #fff;
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  box-shadow: 0 8px 18px rgba(220, 38, 38, .35);
+  z-index: 5;
 }
 
-.step-title {
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--text-dark);
-  margin-bottom: 1rem;
+/* 텍스트 */
+.how-it-works .step-title {
+  margin-top: 12px;
+  font-size: 1.25rem;
+  /* 20px */
+  font-weight: 800;
+  color: #111827;
+  line-height: 1.35;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
 }
 
-.step-desc {
-  color: var(--text-gray);
-  line-height: 1.6;
-  font-size: 1rem;
+.how-it-works .step-desc {
+  margin-top: 12px;
+  font-size: .98rem;
+  color: #6b7280;
+  line-height: 1.7;
+  max-width: 190px;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
 }
 
-.step-connector {
+/* 카드 사이 연결(화살표) */
+.how-it-works .step-connector {
+  flex: 0 0 var(--hiw-conn-w);
   display: flex;
   align-items: center;
-  margin: 0 1rem;
-  position: relative;
+  justify-content: center;
 }
 
-.connector-line {
-  width: 60px;
+.how-it-works .connector-line {
+  width: 100%;
   height: 3px;
-  background: linear-gradient(90deg, var(--primary-orange), var(--primary-orange-light));
   border-radius: 2px;
+  background: linear-gradient(90deg, #f97316, #fb923c);
   position: relative;
 }
 
-.connector-arrow {
-  color: var(--primary-orange);
-  font-weight: bold;
-  font-size: 1.8rem;
-  margin-left: -5px;
-  animation: bounce-horizontal 2s ease-in-out infinite;
+.how-it-works .connector-arrow {
+  margin-left: 6px;
 }
 
-@keyframes bounce-horizontal {
-  0%, 100% { transform: translateX(0); }
-  50% { transform: translateX(5px); }
+.how-it-works .connector-arrow::before {
+  content: '→';
+  display: inline-block;
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #f97316;
+  animation: hiw-bounce-h 1.8s ease-in-out infinite;
+}
+
+@keyframes hiw-bounce-h {
+
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  50% {
+    transform: translateX(6px);
+  }
+}
+
+/* 반응형 */
+@media (max-width: 1024px) {
+  .how-it-works {
+    --hiw-gap: 44px;
+    --hiw-card-w: 250px;
+  }
+}
+
+@media (max-width: 768px) {
+  .how-it-works {
+    --hiw-card-w: 300px;
+    --hiw-card-h: 360px;
+    --hiw-gap: 28px;
+    --hiw-conn-w: 24px;
+  }
+
+  .how-it-works .steps-container {
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+  }
+
+  .how-it-works .step-connector {
+    width: 100%;
+    height: 48px;
+    flex: 0 0 auto;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .how-it-works .connector-line {
+    width: 3px;
+    height: 100%;
+    background: linear-gradient(180deg, #f97316, #fb923c);
+  }
+
+  .how-it-works .connector-arrow {
+    margin-left: 0;
+  }
+
+  .how-it-works .connector-arrow::before {
+    content: '↓';
+    animation: hiw-bounce-v 1.8s ease-in-out infinite;
+  }
+
+  @keyframes hiw-bounce-v {
+
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+
+    50% {
+      transform: translateY(6px);
+    }
+  }
+}
+
+@media (max-width: 420px) {
+  .how-it-works {
+    --hiw-card-w: 92vw;
+  }
 }
 
 /* Map Section */
 .map-section {
-  padding: 6rem 0;
+  padding: 6rem 0 9rem;
+  /* top=6rem, 좌우=0, bottom=9rem (원하는 값으로 조절) */
   background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
+}
+
+.map-section .section-title {
+  --bar-w: 100%;
+  --bar-h: 3px;
 }
 
 .map-container {
@@ -624,10 +799,31 @@
   margin-top: 3rem;
 }
 
+/* 지도 래퍼(= .map-visual)를 카드화 */
 .map-visual {
+  background: #fff;
+  border: 1px solid var(--border-light);
+  border-radius: 2rem;
+  box-shadow: var(--shadow-medium);
+  padding: 1.25rem;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  /* 안쪽 지도를 꽉 채우기 위함 */
+  min-height: 400px;
+  /* 우측 카드와 최소 높이 맞춤(필요 시 값 조절) */
+}
+
+/* 카카오맵 컨테이너가 카드 안을 100% 채우고 모서리도 같이 둥글게 */
+.map-visual #map,
+/* 실제 맵 div의 id/클래스에 맞춰 수정 */
+.map-visual .kakao-map,
+.map-visual .map-placeholder {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100% !important;
+  /* Kakao가 인라인 height:400px 주면 강제 덮어쓰기 */
+  border-radius: 1.25rem;
+  overflow: hidden;
+  /* 둥근 모서리로 타일 잘라내기 */
 }
 
 .map-placeholder {
@@ -668,10 +864,29 @@
   filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
 }
 
-.marker-1 { top: 20%; left: 25%; animation-delay: 0s; }
-.marker-2 { top: 60%; right: 30%; animation-delay: 0.5s; }
-.marker-3 { bottom: 30%; left: 40%; animation-delay: 1s; }
-.marker-4 { top: 40%; right: 15%; animation-delay: 1.5s; }
+.marker-1 {
+  top: 20%;
+  left: 25%;
+  animation-delay: 0s;
+}
+
+.marker-2 {
+  top: 60%;
+  right: 30%;
+  animation-delay: 0.5s;
+}
+
+.marker-3 {
+  bottom: 30%;
+  left: 40%;
+  animation-delay: 1s;
+}
+
+.marker-4 {
+  top: 40%;
+  right: 15%;
+  animation-delay: 1.5s;
+}
 
 .map-content {
   position: relative;
@@ -701,7 +916,7 @@
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(20px);
   border-radius: 2rem;
-  padding: 2.5rem;
+  padding: 1.6rem 2.5rem 2.5rem;
   box-shadow: var(--shadow-medium);
   border: 1px solid rgba(255, 255, 255, 0.5);
 }
@@ -786,6 +1001,11 @@
   background: white;
 }
 
+.benefits-section .section-title {
+  --bar-w: 100%;
+  --bar-h: 3px;
+}
+
 .benefits-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -796,12 +1016,13 @@
 
 .benefit-card {
   position: relative;
-  background: white;
+  background: #fff;
   border-radius: 2rem;
   padding: 3rem 2.5rem;
   text-align: center;
   transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-  border: 2px solid transparent;
+  border: 2px solid var(--border-light);
+  box-shadow: var(--shadow-soft);
   overflow: hidden;
   animation: slideUp 0.8s ease-out forwards;
   animation-delay: var(--delay);
@@ -865,6 +1086,7 @@
   color: var(--text-gray);
   line-height: 1.7;
   font-size: 1.05rem;
+  white-space: pre-line; 
 }
 
 .benefit-hover-effect {
@@ -927,9 +1149,17 @@
 }
 
 @keyframes pulse {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.1); }
-  100% { transform: scale(1); }
+  0% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.1);
+  }
+
+  100% {
+    transform: scale(1);
+  }
 }
 
 .cta-title {
@@ -1006,15 +1236,15 @@
     text-align: center;
     gap: 3rem;
   }
-  
+
   .hero-title {
     font-size: 3rem;
   }
-  
+
   .section-title {
     font-size: 2.5rem;
   }
-  
+
   .cta-title {
     font-size: 2.8rem;
   }
@@ -1025,76 +1255,76 @@
     flex-wrap: wrap;
     gap: 1rem;
   }
-  
+
   .nav-menu {
     gap: 1rem;
   }
-  
+
   .nav-item {
     padding: 0.5rem 1rem;
     font-size: 0.9rem;
   }
-  
+
   .hero-title {
     font-size: 2.5rem;
   }
-  
+
   .section-title {
     font-size: 2rem;
   }
-  
+
   .cta-title {
     font-size: 2.2rem;
   }
-  
+
   .steps-container {
     flex-direction: column;
     align-items: center;
   }
-  
+
   .step-wrapper {
     width: 100%;
     max-width: 350px;
   }
-  
+
   .step-connector {
     flex-direction: column;
     margin: 2rem 0;
     height: 60px;
   }
-  
+
   .connector-line {
     width: 3px;
     height: 40px;
     background: linear-gradient(180deg, var(--primary-orange), var(--primary-orange-light));
   }
-  
+
   .connector-arrow {
     content: '↓';
     margin-left: 0;
     margin-top: -5px;
     transform: rotate(90deg);
   }
-  
+
   .map-container {
     grid-template-columns: 1fr;
     gap: 2rem;
   }
-  
+
   .benefits-grid {
     grid-template-columns: 1fr;
     grid-template-rows: auto;
   }
-  
+
   .cta-buttons {
     flex-direction: column;
     align-items: center;
   }
-  
+
   .cta-trust {
     gap: 1.5rem;
   }
-  
+
   .hero-buttons {
     justify-content: center;
   }
@@ -1104,20 +1334,20 @@
   .container {
     padding: 0 1rem;
   }
-  
+
   .hero-title {
     font-size: 2rem;
   }
-  
+
   .section-title {
     font-size: 1.8rem;
   }
-  
+
   .kiosk-mockup {
     width: 280px;
     height: 420px;
   }
-  
+
   .benefit-card {
     padding: 2rem 1.5rem;
   }
@@ -1146,11 +1376,175 @@
   background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
 }
 
-.from-yellow-400 { --tw-gradient-from: #fbbf24; --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(251, 191, 36, 0)); }
-.to-orange-500 { --tw-gradient-to: #f97316; }
-.from-green-400 { --tw-gradient-from: #4ade80; --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(74, 222, 128, 0)); }
-.to-blue-500 { --tw-gradient-to: #3b82f6; }
-.from-green-400 { --tw-gradient-from: #4ade80; --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(74, 222, 128, 0)); }
-.to-green-600 { --tw-gradient-to: #16a34a; }
-.from-purple-400 { --tw-gradient-from: #a855f7; --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(168, 85, 247, 0)); }
-.to-pink-500 { --tw-gradient-to: #ec4899; }
+.from-yellow-400 {
+  --tw-gradient-from: #fbbf24;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(251, 191, 36, 0));
+}
+
+.to-orange-500 {
+  --tw-gradient-to: #f97316;
+}
+
+.from-green-400 {
+  --tw-gradient-from: #4ade80;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(74, 222, 128, 0));
+}
+
+.to-blue-500 {
+  --tw-gradient-to: #3b82f6;
+}
+
+.from-green-400 {
+  --tw-gradient-from: #4ade80;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(74, 222, 128, 0));
+}
+
+.to-green-600 {
+  --tw-gradient-to: #16a34a;
+}
+
+.from-purple-400 {
+  --tw-gradient-from: #a855f7;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(168, 85, 247, 0));
+}
+
+.to-pink-500 {
+  --tw-gradient-to: #ec4899;
+}
+
+
+/* === How it works: 화살표/커넥터 제거 & 간격 정돈 === */
+.how-it-works {
+  /* 카드 사이 여백만 적당히 주자 */
+  --hiw-gap: clamp(32px, 6vw, 64px);
+  --hiw-conn-w: 0px;
+  /* 커넥터 폭은 0 */
+}
+
+/* 커넥터 완전 숨김 */
+.how-it-works .step-connector,
+.how-it-works .connector-line,
+.how-it-works .connector-arrow {
+  display: none !important;
+}
+
+/* 데스크탑/모바일 모두 gap만으로 정렬 */
+.how-it-works .steps-container {
+  gap: var(--hiw-gap) !important;
+}
+
+/* 모바일 세로 정렬시도 gap만 사용 (커넥터 관련 규칙 무력화) */
+@media (max-width: 768px) {
+  .how-it-works .steps-container {
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(20px, 5vw, 28px) !important;
+  }
+}
+
+
+/* 제목은 선 없이 간격만 */
+.location-header {
+  margin-bottom: .25rem;
+  padding-bottom: 0;
+  border: 0;
+}
+
+/* 제목 아래 필터 행: 위/아래 회색 라인 유지 */
+.location-filters.wide {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr auto;
+  /* 시/구/동/버튼 */
+  gap: .75rem;
+  align-items: center;
+
+  margin-top: .75rem;      /* 제목과 필터 사이 띄우기 */
+  margin-bottom: .75rem;      /* 제목과 필터 사이 띄우기 */
+  /* 제목 ↔ 필터 살짝 간격 */
+  padding: .75rem 0;
+  border-top: 2px solid var(--border-light);
+  border-bottom: 2px solid var(--border-light);
+}
+
+/* 작아진 알약 셀렉트 */
+.ui-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  height: 38px; /* 44 → 38 */
+  min-width: 100px; /* 120 → 100 (필요하면 96까지 가능) */
+  padding: 0 26px 0 10px; /* 오른쪽(화살표 자리) 34 → 26, 왼쪽 12 → 10 */
+  border: 1px solid var(--border-light);
+  border-radius: 9999px;
+  background: #fff;
+  font-weight: 600;
+  color: var(--text-dark);
+  box-shadow: 0 1px 6px rgba(17, 24, 39, .06);
+  /* 커스텀 화살표 */
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiM2YjcyODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIj48cG9seWxpbmUgcG9pbnRzPSI2IDkgMTIgMTUgMTggOSIvPjwvc3ZnPg==");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 12px;       /* 화살표도 살짝 축소 */
+  font-size: 14px;             /* (선택) 글자 약간만 줄이기 */
+  white-space: nowrap;         /* 줄바꿈 방지 */
+}
+
+.ui-select::-ms-expand {
+  display: none;
+}
+
+.ui-select:hover {
+  transform: none;
+  /* 호버 효과 제거 */
+  box-shadow: 0 1px 6px rgba(17, 24, 39, .06);
+}
+
+.ui-select:focus {
+  outline: none;
+  border-color: rgba(249, 115, 22, .6);
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, .12);
+}
+
+/* 작아진 검색 버튼 */
+.ui-btn {
+  height: 38px;
+  /* 44 → 38 */
+  padding: 0 14px;
+  border: none;
+  border-radius: 9999px;
+  font-weight: 700;
+}
+
+.ui-btn.primary {
+  background: linear-gradient(45deg, var(--primary-orange), var(--primary-orange-light));
+  color: #fff;
+  box-shadow: 0 8px 16px rgba(249, 115, 22, .25);
+}
+
+.ui-btn:hover {
+  /* 호버 애니메이션 제거 */
+  transform: none;
+  box-shadow: 0 8px 16px rgba(249, 115, 22, .25);
+}
+
+/* 반응형 */
+@media (max-width: 900px) {
+  .location-filters.wide {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .location-filters.wide .ui-btn {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 640px) {
+  .location-filters.wide {
+    grid-template-columns: 1fr;
+  }
+
+  .location-filters.wide .ui-btn {
+    grid-column: auto;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
<관리자 페이지 - 키오스크탭 React 리스트 key 중복 경고, 상태 표시 누락 문제 발생>
원인: 리스트 렌더링 시 key={kiosk.name}을 사용했는데, name은 중복되거나 변할 수 있어 React가 고유 key를 보장하지 못해 경고 발생.

+ 상태 표시 누락 문제 
증상: 백엔드에서 status=OFFLINE 값을 내려줘도 화면에는 '알수없음'으로만 표시됨.
원인: 상태 매핑 로직(statusToCss, status badge)에서 ONLINE/MAINT만 처리하고 OFFLINE은 누락되어 있었음.

해결: 
CollectionHistoryTab.js
- 리스트 key를 name → recycleId(PK 성격의 값)로 교체 → React Key 경고 해결
- OFFLINE 상태를 inactive 클래스 + '미운영' 텍스트로 추가 매핑 → 상태 표시 누락 해결


<관리자 페이지 - 키오스크탭에서 특정 항목 선택 시 콘솔에 AxiosError 404 (Not Found)>
증상: 키오스크 탭에서 특정 항목 선택 시 콘솔에 AxiosError 404 (Not Found), 요청 예: GET /api/admin/kiosk/log/list?pageNum=1&amount=50&kioskId=2
원인: 하나의 상태(selectedKiosk)를 두 탭이 같이 써서, 수거내역 드롭다운(recycleId)의 값이 키오스크 탭으로 넘어오고, 그 값이 kioskId로 전송됨. 또한 'all'이나 문자열 타입이 그대로 붙어 전송되기도 함.
해결:
상태 분리(selectedRecycleId, selectedKioskId)로 ID 혼용 차단
키오스크 로그 로딩 시 ...(selectedKioskId === 'all' ? {} : { kioskId: Number(selectedKioskId) })로 숫자 변환/전체 제외
필터 함수 및 각 탭의 props 전달 대상 변경으로 일관성 유지

AdminDashboard.js
- 키오스크 로그 로딩 시 kioskId 숫자 변환 및 'all'일 때 파라미터 제외 처리
- getFilteredKioskData/getFilteredRecycleStats 함수 분리 및 props 전달 대상 교정
- 로그 응답 안전 폴백(list ?? [] / 실패 시 [])

CollectionHistoryTab.js
- props를 selectedRecycleId/setSelectedRecycleId로 교체
- 드롭다운 value/key를 recycleId 기반으로 일원화


<관리자 페이지 - 키오스크탭에서 특정 키오스크 선택 시 키오스크 로그 API가 500을 반환>
초기: 결과 0건도 예외로 처리되어 컨트롤러에서 404 반환 → 프론트는 에러로 인식.
중간: 예외 경로가 바뀌며 실제로는 500까지 발생(서비스에서 0건을 예외로 던짐).
최종: 0건은 정상 케이스로 보고 200 OK + 빈 목록([]) 로 통일. 진짜 서버 오류만 500.

KioskRunMapper.xml
- status='' 입력 시 조건 제외하도록 보강 (쿼리 안정성)
KioskRunServiceImpl
- getTotalRunCount에서 0건을 정상 처리(예외 제거), 오류 시 0으로 폴백
AdminKioskApiController
- kioskRunList 조회 시 빈 결과도 200 OK + [] 반환, null→[] 폴백 및 요청 파라미터 로깅 추가


<관리자 페이지 - 키오스크탭에서 취소/완료 상태 선택 시 키오스크 로그 API가 500을 반환>
원인: 매퍼에서 status != '' 조건이 적용돼 빈 문자열과 Enum 비교가 발생 → 쿼리 오류 유발
해결: 조건을 status != null로 수정해 Enum만 비교되도록 변경, 정상 조회 가능.
KioskRunMapper.xml
- kioskRunWhere 조건 보강 수정: status != '' 제거 → Enum 비교 오류(취소/완료 조회 시 500) 해결


<관리자 페이지 - 키오스크탭에서 로그기록  페이징처리>
AdminDashboard.js
- 키오스크 로그 페이징 도입: selectedPage/kioskRunPageInfo 상태 추가, getKioskRuns 호출에 pageNum/amount 반영, KioskTab에 pageInfo·setSelectedPage 전달
KioskTab.js
- 로그 페이징 UI 추가(log-pagination): 서버 pageInfo 기반 이전/번호/다음 버튼 렌더링, 필터 변경 시 페이지 1로 리셋(setSelectedPage(1)) 처리
AdminDashboard.css


<메인페이지 css 수정>
1) “어떻게 사용하나요?” (How it works)
- 기존 How-it-works 관련 CSS 전량 삭제하고 새로 작성.
- 연결 화살표/라인 완전 제거 (귓속말 느낌의 장식 대신 카드들 간 간격만).
- 숫자 배지(step-number) 위치를 왼쪽 위로 이동.
- 카드 자체에 라운드·보더·소프트 그림자 추가, 호버 시 살짝 떠오르는 효과.
- 제목과 카드 사이 세로 간격 확장.

2) “가까운 키오스크 찾기” (Map 섹션 우측 카드 + 필터)
- 지도 영역을 카드처럼 보이도록 래퍼 추가
→ JS에서 지도를 <div className="map-visual">로 감쌌고,
→ CSS에서 .map-visual에 보더/라운드/섀도/패딩 적용.
- 우측 리스트 카드에서 제목(“주변 키오스크”)을 위로 당김(상단 패딩 축소).
- 제목 줄의 구분선 제거, 대신 필터 행에만 회색 라인(위·아래) 유지.
- 알약 셀렉트/버튼 크기 축소, 호버 애니메이션 제거

3) “PETCOIN의 특별한 장점” (Benefits 카드)
원래는 효과 없음 → 카드화(라운드, 보더, 소프트 그림자).
슬라이드업 진입 애니메이션 + 호버 시 살짝 확대 & 섀도 강화.
그라데이션 오버레이와 래디얼 하이라이트 추가로 “촉감” 살림.
설명 문장을 지정 위치에서 줄바꿈하도록 JS 문구에 \n 삽입 + CSS white-space: pre-line.

