### PR TITLE
[20250917] 키오스크 오류 수정

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,8 +1,8 @@
 # 스프링부트 API (회원/JWT/포인트/세션 등)
-REACT_APP_API_URL=http://localhost:8080
+# REACT_APP_API_URL=http://localhost:8080
 
 # 아이패드 API (키오스크 화면)
-# REACT_APP_API_URL=http://192.168.10.72:8080
+REACT_APP_API_URL=http://192.168.10.72:8080
 
 
 # 라즈베리파이 API (컨베이어/AI 요청/결과)

--- a/frontend/src/kiosk/KioskApp.js
+++ b/frontend/src/kiosk/KioskApp.js
@@ -28,6 +28,7 @@
  *   - 250905 | yukyeong | JWT 디코딩으로 memberId 추출 로직 정리 및 runId 가드 추가
  *   - 250905 | yukyeong | CompletionScreen에 status="DONE" 전달(취소/에러 시 종료 API 호출 방지와 연계)
  *   - 250908 | yukyeong | CompletionScreen에 memberId 전달 → Boot API(getPointChange)로 잔여 포인트 조회; runId는 표시/디버깅용으로 유지
+ *   - 250917 | yukyeong | 예외/실패 플로우 일원화: InsertBottleScreen에 onHome 전달, ProcessingScreen onComplete에 runId 가드 및 실패 시 alert+handleGoHome 처리
  * 
  */
 
@@ -112,6 +113,7 @@ function KioskApp() {
             }}
             // 뒤로가기: 회원이면 Step2, 비회원이면 Step1
             onBack={() => (accessToken ? goToStep(2) : goToStep(1))}
+            onHome={handleGoHome}   // ✅ 홈 초기화 함수 전달
             accessToken={accessToken} // 필요 시 API 호출용
             memberId={memberId} // 동적으로 추출
             kioskId={kioskId} // 기기 고유값

--- a/frontend/src/kiosk/components/ProcessingScreen.js
+++ b/frontend/src/kiosk/components/ProcessingScreen.js
@@ -29,6 +29,7 @@
  *   - 250905 | yukyeong | Flask 응답 done을 엄격 비교(res?.data?.done === true)로 변경, totalPet 안전 파싱 보강
  *   - 250905 | yukyeong | onComplete에 status('DONE'|'TIMEOUT'|'ERROR') 포함하도록 계약 
  *   - 250908 | yukyeong | 폴링 최대 재시도 시간을 60초(30회) → 5분(150회)로 확장(2초 간격 유지)
+ *   - 250917 | yukyeong | 폴링 최대 재시도 시간을 5분(150회) → 2분(60회)로 단축, UX 개선
  */
 
 import React, { useEffect } from 'react';
@@ -47,7 +48,7 @@ const ProcessingScreen = ({ runId, onComplete }) => {
     }
 
     let attempts = 0;
-    const maxAttempts = 150; // 5분
+    const maxAttempts = 60; // 2분
     let isMounted = true;
 
     const interval = setInterval(async () => {


### PR DESCRIPTION
<세션 도중 오류나 비정상 종료 시 runId가 남아서 중복 실행·상태 불일치가 발생하는 문제를 막고, 사용자에게 안내 후 안전하게 홈으로 복귀시키기 위해서 수정>
[InsertBottleScreen.js]
시작 실패 시 runId 생성 이후 예외 발생하면 cancelKioskRun 호출 후 홈으로 안전 복귀 처리

[KioskApp.js]
예외/실패 플로우 일원화: InsertBottleScreen에 onHome 전달, ProcessingScreen onComplete에 runId 가드 및 실패 시 alert+handleGoHome 처리

<사용자가 분석 완료를 기다리는 시간이 너무 길어(5분) → 실패인지 아닌지 불확실하게 방치되는 문제가 있었기 때문에,
최대 대기 시간을 2분으로 줄여서 빠르게 실패 안내(타임아웃 alert) 후 홈으로 복귀시켜 UX를 개선하기 위해 수정>
[ProcessingScreen.js]
폴링 최대 재시도 시간을 5분(150회) → 2분(60회)로 단축, UX 개선
